### PR TITLE
Fix `set_local_name` panic due to incorrect buffer size

### DIFF
--- a/src/client/settings.rs
+++ b/src/client/settings.rs
@@ -50,16 +50,17 @@ impl<'a> BlueZClient<'a> {
                 });
             }
         }
+        let short_name = short_name.unwrap_or("");
 
         let mut param = BytesMut::with_capacity(260);
         param.resize(260, 0); // initialize w/ zeros
 
         CString::new(name)?
             .as_bytes_with_nul()
-            .copy_to_slice(&mut param[..249]);
-        CString::new(short_name.unwrap_or(""))?
+            .copy_to_slice(&mut param[..=name.len()]);
+        CString::new(short_name)?
             .as_bytes_with_nul()
-            .copy_to_slice(&mut param[249..]);
+            .copy_to_slice(&mut param[249..][..=short_name.len()]);
 
         self.exec_command(
             Command::SetLocalName,


### PR DESCRIPTION
The [`copy_to_slice`](https://docs.rs/bytes/0.5.4/bytes/buf/trait.Buf.html#method.copy_to_slice`) function is used to copy the device name into a data buffer.

> The cursor is advanced by the number of bytes copied. `self` must have enough remaining bytes to fill `dst`.

According to it's documentation the destination buffer may not be bigger than the source. Therefore I made the destination buffer the same size as the source instead of the maximum size to fix the panic I encountered in #1.

Fixes https://github.com/laptou/bluez-rs/issues/1