### PR TITLE
Update bitvec from v0.16 to v0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitvec"
-version = "0.16.2"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -67,7 +67,7 @@ name = "bluez"
 version = "0.1.2"
 dependencies = [
  "async-std 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitvec 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitvec 0.17.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "enumflags2 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -558,7 +558,7 @@ dependencies = [
 "checksum async-task 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0ac2c016b079e771204030951c366db398864f5026f84a44dafb0ff20f02085d"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-"checksum bitvec 0.16.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3f62134ef3d3f415729bdded77da1e0803af4409e7a7554ee486081c0cffbf82"
+"checksum bitvec 0.17.4 (registry+https://github.com/rust-lang/crates.io-index)" = "41262f11d771fd4a61aa3ce019fca363b4b6c282fca9da2a31186d3965a47a5c"
 "checksum bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum crossbeam-channel 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ num-traits = "0.2"
 num-derive = "0.3"
 enumflags2 = "0.6"
 bytes = "0.5"
-bitvec = "0.16"
+bitvec = "0.17"
 futures = "0.3"
 async-std = { version = "1.4", features = ["attributes"] }
 

--- a/src/interface/class.rs
+++ b/src/interface/class.rs
@@ -1,5 +1,5 @@
 use bitvec::prelude as bv;
-use bitvec::prelude::{BitField, Bits};
+use bitvec::prelude::{BitField, AsBits};
 use bytes::Bytes;
 use enumflags2::BitFlags;
 
@@ -158,13 +158,13 @@ pub fn from_array(class: [u8; 3]) -> (DeviceClass, ServiceClasses) {
 pub fn from_u32(class: u32) -> (DeviceClass, ServiceClasses) {
     let service_classes = ServiceClasses::from_bits_truncate(class);
 
-    let class_bits = class.bits::<bv::LittleEndian>();
+    let class_bits = class.bits::<bv::Lsb0>();
     let device_class: DeviceClass;
 
     // major device class encoded in bits 8-12
-    device_class = match class_bits[8..13].load::<u8>().unwrap() {
+    device_class = match class_bits[8..13].load::<u8>() {
         // minor device class in bits 2-7
-        0b00001 => DeviceClass::Computer(match class_bits[2..8].load::<u8>().unwrap() {
+        0b00001 => DeviceClass::Computer(match class_bits[2..8].load::<u8>() {
             0b000000 => ComputerDeviceClass::Uncategorized,
             0b000001 => ComputerDeviceClass::Desktop,
             0b000010 => ComputerDeviceClass::Server,
@@ -175,7 +175,7 @@ pub fn from_u32(class: u32) -> (DeviceClass, ServiceClasses) {
             0b000111 => ComputerDeviceClass::Tablet,
             _ => ComputerDeviceClass::Unknown,
         }),
-        0b00010 => DeviceClass::Phone(match class_bits[2..8].load::<u8>().unwrap() {
+        0b00010 => DeviceClass::Phone(match class_bits[2..8].load::<u8>() {
             0b000000 => PhoneDeviceClass::Uncategorized,
             0b000001 => PhoneDeviceClass::Cellular,
             0b000010 => PhoneDeviceClass::Cordless,
@@ -185,7 +185,7 @@ pub fn from_u32(class: u32) -> (DeviceClass, ServiceClasses) {
             _ => PhoneDeviceClass::Unknown,
         }),
         0b00011 => DeviceClass::AccessPoint(0.),
-        0b00100 => DeviceClass::AudioVideo(match class_bits[2..8].load::<u8>().unwrap() {
+        0b00100 => DeviceClass::AudioVideo(match class_bits[2..8].load::<u8>() {
             0b000001 => AudioVideoDeviceClass::Headset,
             0b000010 => AudioVideoDeviceClass::HandsFree,
             0b000011 => AudioVideoDeviceClass::Unknown,
@@ -209,7 +209,7 @@ pub fn from_u32(class: u32) -> (DeviceClass, ServiceClasses) {
         0b00101 => DeviceClass::Peripheral {
             keyboard: class_bits[6],
             pointer: class_bits[7],
-            class: match class_bits[2..6].load::<u8>().unwrap() {
+            class: match class_bits[2..6].load::<u8>() {
                 0b0000 => PeripheralDeviceClass::Uncategorized,
                 0b0001 => PeripheralDeviceClass::Joystick,
                 0b0010 => PeripheralDeviceClass::Gamepad,
@@ -229,7 +229,7 @@ pub fn from_u32(class: u32) -> (DeviceClass, ServiceClasses) {
             scanner: class_bits[6],
             printer: class_bits[7],
         },
-        0b00111 => DeviceClass::Wearable(match class_bits[2..8].load::<u8>().unwrap() {
+        0b00111 => DeviceClass::Wearable(match class_bits[2..8].load::<u8>() {
             0b0001 => WearableDeviceClass::Wristwatch,
             0b0010 => WearableDeviceClass::Pager,
             0b0011 => WearableDeviceClass::Jacket,
@@ -237,7 +237,7 @@ pub fn from_u32(class: u32) -> (DeviceClass, ServiceClasses) {
             0b0101 => WearableDeviceClass::Glasses,
             _ => WearableDeviceClass::Unknown,
         }),
-        0b01000 => DeviceClass::Toy(match class_bits[2..8].load::<u8>().unwrap() {
+        0b01000 => DeviceClass::Toy(match class_bits[2..8].load::<u8>() {
             0b0001 => ToyDeviceClass::Robot,
             0b0010 => ToyDeviceClass::Vehicle,
             0b0011 => ToyDeviceClass::Doll,
@@ -245,7 +245,7 @@ pub fn from_u32(class: u32) -> (DeviceClass, ServiceClasses) {
             0b0101 => ToyDeviceClass::Game,
             _ => ToyDeviceClass::Unknown,
         }),
-        0b01001 => DeviceClass::Health(match class_bits[2..8].load::<u8>().unwrap() {
+        0b01001 => DeviceClass::Health(match class_bits[2..8].load::<u8>() {
             0b000001 => HealthDeviceClass::BloodPressureMeter,
             0b000010 => HealthDeviceClass::Thermometer,
             0b000011 => HealthDeviceClass::WeightScale,


### PR DESCRIPTION
Bits trait was renamed to AsBits in v0.17.1 and LittleEndian/BigEndian
were renamed Lsb0 and Msb0 respectively.

Fixes #7 