### PR TITLE
Fix examples link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A library for controlling Bluetooth on Linux.
 [![crates.io](https://img.shields.io/crates/l/bluez.svg?style=for-the-badge)](https://github.com/laptou/bluez-rs/blob/master/LICENSE)
 
 [Documentation](https://docs.rs/bluez)
-[Examples](https://github.com/laptou/bluez-rs/blob/master/src/example/)
+[Examples](https://github.com/laptou/bluez-rs/tree/master/examples)
 
 Some of the examples require elevated permissions. For example, to run the `discover` example, clone this repository, `cargo build`, and then `sudo target/debug/discover`.
 `sudo` is necessary because many of the functions of this crate are not possible without the `CAP_NET_RAW` capability.


### PR DESCRIPTION
The link to the examples link was broken, as it used the GitHub URL format pointing to individual, raw files but not directories. This corrects the link to point to the examples directory.