### PR TITLE
Add support for Default System/Runtime configuration 

### DIFF
--- a/src/client/params.rs
+++ b/src/client/params.rs
@@ -1,3 +1,5 @@
+use std::hash::Hash;
+
 use enumflags2::BitFlags;
 
 use crate::Address;
@@ -199,3 +201,41 @@ pub enum PhyFlag {
     LECodedTx = 1 << 13,
     LECodedRx = 1 << 14,
 }
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, FromPrimitive)]
+#[repr(u16)]
+pub enum SystemConfigParameterType {
+    BREDRPageScanType = 0x0000,
+    BREDRPageScanInterval,
+    BREDRPageScanWindow,
+    BREDRInquiryScanType,
+    BREDRInquiryScanInterval,
+    BREDRInquiryScanWindow,
+    BREDRLinkSupervisionTimeout,
+    BREDRPageTimeout,
+    BREDRMinSniffInterval,
+    BREDRMaxSniffInterval,
+    LEAdvertisementMinInterval,
+    LEAdvertisementMaxInterval,
+    LEMultiAdvertisementRotationInterval,
+    LEScanningIntervalForAutoConnect,
+    LEScanningWindowForAutoConnect,
+    LEScanningIntervalForWakeScenarios,
+    LEScanningWindowForWakeScenarios,
+    LEScanningIntervalForDiscovery,
+    LEScanningWindowForDiscovery,
+    LEScanningIntervalForAdvMonitoring,
+    LEScanningWindowForAdvMonitoring,
+    LEScanningIntervalForConnect,
+    LEScanningWindowForConnect,
+    LEMinConnectionInterval,
+    LEMaxConnectionInterval,
+    LEConnectionLatency,
+    LEConnectionSupervisionTimeout,
+    LEAutoconnectTimeout,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, FromPrimitive)]
+//#[repr(u16)] once there are known variants
+#[non_exhaustive]
+pub enum RuntimeConfigParameterType {}

--- a/src/client/query.rs
+++ b/src/client/query.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::interface::class::from_bytes as class_from_bytes;
 use crate::interface::controller::ControllerInfoExt;
 use crate::util::BufExt2;
@@ -379,6 +381,35 @@ impl<'a> BlueZClient<'a> {
                 configurable_phys: param.get_flags_u32_le(),
                 selected_phys: param.get_flags_u32_le(),
             })
+        })
+        .await
+    }
+
+    /// Currently no Parameter_Type values are defined and an empty list
+    /// will be returned.
+    ///
+    /// This command can be used at any time and will return a list of
+    /// supported default parameters as well as their current value.
+    pub async fn get_default_runtime_config(
+        &mut self,
+        controller: Controller,
+    ) -> Result<HashMap<RuntimeConfigParameterType, Vec<u8>>> {
+        self.exec_command(Command::ReadDefaultRuntimeConfig, controller, None, |_, param| {
+            let mut param = param.unwrap();
+            Ok(param.get_tlv_map())
+        })
+        .await
+    }
+
+    /// This command can be used at any time and will return a list of
+    /// supported default parameters as well as their current value.
+    pub async fn get_default_system_config(
+        &mut self,
+        controller: Controller,
+    ) -> Result<HashMap<SystemConfigParameterType, Vec<u8>>> {
+        self.exec_command(Command::ReadDefaultSystemConfig, controller, None, |_, param| {
+            let mut param = param.unwrap();
+            Ok(param.get_tlv_map())
         })
         .await
     }

--- a/src/interface/command.rs
+++ b/src/interface/command.rs
@@ -99,6 +99,19 @@ pub enum Command {
     GetPhyConfig,
     SetPhyConfig,
     LoadBlockedKeys,
+    SetWidebandSpeech,
+    ReadSecurityInfo,
+    ReadExperimentalFeaturesInfo,
+    SetExperimentalFeature,
+    ReadDefaultSystemConfig,
+    SetDefaultSystemConfig,
+    ReadDefaultRuntimeConfig,
+    SetDefaultRuntimeConfig,
+    GetDeviceFlags,
+    SetDeviceFlags,
+    ReadAdvertisementMonitorFeatures,
+    AddAdvertisementPatternsMonitor,
+    RemoveAdvertisementMonitor,
 }
 
 impl fmt::LowerHex for CommandStatus {

--- a/src/interface/controller.rs
+++ b/src/interface/controller.rs
@@ -77,6 +77,8 @@ pub enum ControllerSetting {
     Privacy = 1 << 13,
     Configuration = 1 << 14,
     StaticAddress = 1 << 15,
+    PhyConfiguration = 1 << 16,
+    WidebandSpeech = 1 << 17,
 }
 
 pub type ControllerSettings = BitFlags<ControllerSetting>;

--- a/src/interface/event.rs
+++ b/src/interface/event.rs
@@ -8,6 +8,7 @@ use crate::interface::class::{DeviceClass, ServiceClasses};
 use crate::interface::controller::ControllerSettings;
 use crate::interface::{Command, CommandStatus};
 use crate::Address;
+use std::collections::HashMap;
 
 #[derive(Debug)]
 pub enum Event {
@@ -433,4 +434,30 @@ pub enum Event {
     ///	The event will only be sent to management sockets other than the
     ///	one through which the command was sent.
     PhyConfigChanged { selected_phys: BitFlags<PhyFlag> },
+
+    ///	This event indicates that the status of an experimental feature
+    ///	has been changed.
+    ///
+    ///	The event will only be sent to management sockets other than the
+    ///	one through which the change was triggered.
+    ExperimentalFeatureChanged {
+        uuid: [u8; 16],
+        flags: u32,
+    },
+
+    ///	This event indicates the change of default system parameter values.
+    ///
+    /// The event will only be sent to management sockets other than the
+    ///	one through which the change was trigged. In addition it will
+    ///	only be sent to sockets that have issues the Read Default System
+    ///	Configuration command.
+    DefaultSystemConfigChanged { params: HashMap<SystemConfigParameterType, Vec<u8>> },
+
+    ///	This event indicates the change of default runtime parameter values.
+    ///
+    ///	The event will only be sent to management sockets other than the
+    ///	one through which the change was trigged. In addition it will
+    ///	only be sent to sockets that have issues the Read Default Runtime
+    ///	Configuration command.
+    DefaultRuntimeConfigChanged { params: HashMap<RuntimeConfigParameterType, Vec<u8>> },
 }

--- a/src/interface/response.rs
+++ b/src/interface/response.rs
@@ -219,7 +219,7 @@ impl Response {
                 0x0026 => Event::PhyConfigChanged {
                     selected_phys: BitFlags::from_bits_truncate(buf.get_u32_le()),
                 },
-                _ => todo!("throw error instead of panicking"),
+                _ => return Err(Error::UnknownEventCode { evt_code }),
             },
         })
     }

--- a/src/interface/response.rs
+++ b/src/interface/response.rs
@@ -219,6 +219,16 @@ impl Response {
                 0x0026 => Event::PhyConfigChanged {
                     selected_phys: BitFlags::from_bits_truncate(buf.get_u32_le()),
                 },
+                0x0027 => Event::ExperimentalFeatureChanged {
+                    uuid: buf.get_u8x16(),
+                    flags: buf.get_u32_le(),
+                },
+                0x0028 => Event::DefaultSystemConfigChanged {
+                    params: buf.get_tlv_map()
+                },
+                0x0029 => Event::DefaultRuntimeConfigChanged {
+                    params: buf.get_tlv_map()
+                },
                 _ => return Err(Error::UnknownEventCode { evt_code }),
             },
         })

--- a/src/result.rs
+++ b/src/result.rs
@@ -13,7 +13,7 @@ pub enum Error {
         #[source]
         source: ::std::io::Error,
     },
-    #[error("Command {:?} returned {:?}.", status, opcode)]
+    #[error("Command {:?} returned {:?}.", opcode, status)]
     CommandError {
         opcode: Command,
         status: CommandStatus,

--- a/src/result.rs
+++ b/src/result.rs
@@ -22,6 +22,8 @@ pub enum Error {
     UnknownOpcode { opcode: u16 },
     #[error("Unknown command status: {:x}.", status)]
     UnknownStatus { status: u8 },
+    #[error("Unknown event code: {:x}.", evt_code)]
+    UnknownEventCode { evt_code: u16 },
     #[error("Timed out.")]
     TimedOut,
     #[error("The socket received invalid data.")]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,6 @@
+use std::collections::HashMap;
 use std::ffi::CString;
+use std::hash::Hash;
 
 use bytes::Buf;
 use enumflags2::BitFlags;
@@ -18,6 +20,12 @@ pub(crate) trait BufExt2: Buf {
         let mut arr = [0u8; 16];
         self.copy_to_slice(&mut arr[..]);
         arr
+    }
+
+    fn get_vec_u8(&mut self, len: usize) -> Vec<u8> {
+        let mut ret = vec![0; len];
+        self.copy_to_slice(ret.as_mut_slice());
+        ret
     }
 
     fn get_bool(&mut self) -> bool {
@@ -52,6 +60,34 @@ pub(crate) trait BufExt2: Buf {
             current = self.get_u8();
         }
         return unsafe { CString::from_vec_unchecked(bytes) };
+    }
+
+    /// Parses a list of Type/Length/Value entries into a map keyed by type
+    ///
+    /// This parses a list of mgmt_tlv entries (as defined in mgmt.h) and converts them
+    /// into a map of Type => Vec<u8>.
+    ///
+    /// # Bytes layout
+    ///
+    /// The layout as described in the mgmt-api documentation is:
+    /// ```plain
+    ///   Parameter1 {
+    ///       Parameter_Type (2 Octet)
+    ///       Value_Length (1 Octet)
+    ///       Value (0-255 Octets)
+    ///   }
+    ///   Parameter2 { }
+    ///   ...
+    /// ```
+    ///
+    fn get_tlv_map<T : FromPrimitive + Eq + Hash>(&mut self) -> HashMap<T, Vec<u8>> {
+        let mut parameters = HashMap::new();
+        while self.has_remaining() {
+            let parameter_type: T = self.get_primitive_u16_le();
+            let value_size = self.get_u8() as usize;
+            parameters.insert(parameter_type, self.get_vec_u8(value_size));
+        }
+        parameters
     }
 }
 


### PR DESCRIPTION
This pull request adds support for the Read/Set Default System/Runtime configuration commands defined in 1.18 (available in Kernel 5.9).

This change does add all missing commands, but does not implement high-level methods for all of them, nor all of the newly introduced events. Please let me know if this is not acceptable.

This change also includes minor fixes:
* an argument flip in CommandError error message
* a new UnknownEventCode error so that the library doesn't panic when it encounters unknown events