### PR TITLE
Various linting cleanups

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -44,9 +44,9 @@ impl From<[u8; 6]> for Address {
     }
 }
 
-impl Into<[u8; 6]> for Address {
-    fn into(self) -> [u8; 6] {
-        self.bytes
+impl From<Address> for [u8; 6] {
+    fn from(val: Address) -> Self {
+        val.bytes
     }
 }
 

--- a/src/address.rs
+++ b/src/address.rs
@@ -40,7 +40,7 @@ impl Address {
 
 impl From<[u8; 6]> for Address {
     fn from(bytes: [u8; 6]) -> Self {
-        return Address { bytes };
+        Address { bytes }
     }
 }
 

--- a/src/communication/socket.rs
+++ b/src/communication/socket.rs
@@ -159,7 +159,7 @@ impl BluetoothListener {
             _ => unreachable!(),
         } as u32;
 
-        let fd = check_error(unsafe {
+        check_error(unsafe {
             libc::getsockname(
                 self.inner.as_raw_fd(),
                 &mut addr as *mut _ as *mut _,
@@ -340,7 +340,7 @@ impl BluetoothStream {
             _ => unreachable!(),
         } as u32;
 
-        let fd = check_error(unsafe {
+        check_error(unsafe {
             libc::getsockname(
                 self.inner.as_raw_fd(),
                 &mut addr as *mut _ as *mut _,
@@ -365,7 +365,7 @@ impl BluetoothStream {
             _ => unreachable!(),
         } as u32;
 
-        let fd = check_error(unsafe {
+        check_error(unsafe {
             libc::getpeername(
                 self.inner.as_raw_fd(),
                 &mut addr as *mut _ as *mut _,

--- a/src/communication/socket.rs
+++ b/src/communication/socket.rs
@@ -1,6 +1,6 @@
 use std::io::{Read, Write};
 use std::mem::MaybeUninit;
-use std::os::unix::net::{UnixListener, UnixStream};
+use std::os::unix::net::UnixStream;
 use std::os::unix::prelude::IntoRawFd;
 
 use libc::{self, c_int};

--- a/src/management/client/advertising.rs
+++ b/src/management/client/advertising.rs
@@ -3,12 +3,12 @@ use crate::util::BufExtBlueZ;
 use enumflags2::{BitFlags, bitflags};
 
 impl<'a> ManagementClient<'a> {
-    ///	This command is used to read the advertising features supported
-    ///	by the controller and stack. The `max_adv_data_len` and `max_scan_rsp_len` provides extra
-    ///	information about the maximum length of the data fields. For
-    ///	now this will always return the value 31. Different flags
-    ///	however might decrease the actual available length in these
-    ///	data fields.
+    /// This command is used to read the advertising features supported
+    /// by the controller and stack. The `max_adv_data_len` and `max_scan_rsp_len` provides extra
+    /// information about the maximum length of the data fields. For
+    /// now this will always return the value 31. Different flags
+    /// however might decrease the actual available length in these
+    /// data fields.
     pub async fn get_advertising_features(
         &mut self,
         controller: Controller,
@@ -34,66 +34,66 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to configure an advertising instance that
-    ///	can be used to switch a Bluetooth Low Energy controller into
-    ///	advertising mode.
+    /// This command is used to configure an advertising instance that
+    /// can be used to switch a Bluetooth Low Energy controller into
+    /// advertising mode.
     ///
-    ///	Added advertising information with this command will not be visible
-    ///	immediately if advertising is enabled via the Set Advertising
-    ///	command. The usage of the Set Advertising command takes precedence
-    ///	over this command. Instance information is stored and will be
-    ///	advertised once advertising via Set Advertising has been disabled.
+    /// Added advertising information with this command will not be visible
+    /// immediately if advertising is enabled via the Set Advertising
+    /// command. The usage of the Set Advertising command takes precedence
+    /// over this command. Instance information is stored and will be
+    /// advertised once advertising via Set Advertising has been disabled.
     ///
-    ///	The Instance identifier is a value between 1 and the number of
-    ///	supported instances. The value 0 is reserved.
+    /// The Instance identifier is a value between 1 and the number of
+    /// supported instances. The value 0 is reserved.
     /// When the connectable flag is set, then the controller will use
-    ///	undirected connectable advertising. The value of the connectable
-    ///	setting can be overwritten this way. This is useful to switch a
-    ///	controller into connectable mode only for LE operation. This is
-    ///	similar to the mode 0x02 from the Set Advertising command.
+    /// undirected connectable advertising. The value of the connectable
+    /// setting can be overwritten this way. This is useful to switch a
+    /// controller into connectable mode only for LE operation. This is
+    /// similar to the mode 0x02 from the Set Advertising command.
     ///
-    ///	Secondary channel flags can be used to advertise in secondary
-    ///	channel with the corresponding PHYs. These flag bits are mutually
-    ///	exclusive and setting multiple will result in Invalid Parameter
-    ///	error. Choosing either LE 1M or LE 2M will result in using
-    ///	extended advertising on the primary channel with LE 1M and the
-    ///	respectively LE 1M or LE 2M on the secondary channel. Choosing
-    ///	LE Coded will result in using extended advertising on the primary
-    ///	and secondary channels with LE Coded. Choosing none of these flags
-    ///	will result in legacy advertising.
+    /// Secondary channel flags can be used to advertise in secondary
+    /// channel with the corresponding PHYs. These flag bits are mutually
+    /// exclusive and setting multiple will result in Invalid Parameter
+    /// error. Choosing either LE 1M or LE 2M will result in using
+    /// extended advertising on the primary channel with LE 1M and the
+    /// respectively LE 1M or LE 2M on the secondary channel. Choosing
+    /// LE Coded will result in using extended advertising on the primary
+    /// and secondary channels with LE Coded. Choosing none of these flags
+    /// will result in legacy advertising.
     ///
-    ///	If only one advertising Instance has been added, then the `duration`
-    ///	value will be ignored. It only applies for the case where multiple
-    ///	Instances are configured. In that case every Instance will be
-    ///	available for the `duration` time and after that it switches to
-    ///	the next one. This is a simple round-robin based approach.
+    /// If only one advertising Instance has been added, then the `duration`
+    /// value will be ignored. It only applies for the case where multiple
+    /// Instances are configured. In that case every Instance will be
+    /// available for the `duration` time and after that it switches to
+    /// the next one. This is a simple round-robin based approach.
     ///
-    ///	When a `timeout` is provided, then the `duration` subtracts from
-    ///	the actual `timeout` value of that Instance. For example an Instance
-    ///	with `timeout` of 5 and `duration` of 2 will be scheduled exactly 3
-    ///	times, twice with 2 seconds and once with one second. Other
-    ///	Instances have no influence on the `timeout`.
+    /// When a `timeout` is provided, then the `duration` subtracts from
+    /// the actual `timeout` value of that Instance. For example an Instance
+    /// with `timeout` of 5 and `duration` of 2 will be scheduled exactly 3
+    /// times, twice with 2 seconds and once with one second. Other
+    /// Instances have no influence on the `timeout`.
     ///
-    ///	Re-adding an already existing instance (i.e. issuing the Add
-    ///	Advertising command with an Instance identifier of an existing
-    ///	instance) will update that instance's configuration.
+    /// Re-adding an already existing instance (i.e. issuing the Add
+    /// Advertising command with an Instance identifier of an existing
+    /// instance) will update that instance's configuration.
     ///
-    ///	An instance being added or changed while another instance is
-    ///	being advertised will not be visible immediately but only when
-    ///	the new/changed instance is being scheduled by the round robin
-    ///	advertising algorithm.
+    /// An instance being added or changed while another instance is
+    /// being advertised will not be visible immediately but only when
+    /// the new/changed instance is being scheduled by the round robin
+    /// advertising algorithm.
     ///
-    ///	Changes to an instance that is currently being advertised will
-    ///	cancel that instance and switch to the next instance. The changes
-    ///	will be visible the next time the instance is scheduled for
-    ///	advertising. In case a single instance is active, this means
-    ///	that changes will be visible right away.
+    /// Changes to an instance that is currently being advertised will
+    /// cancel that instance and switch to the next instance. The changes
+    /// will be visible the next time the instance is scheduled for
+    /// advertising. In case a single instance is active, this means
+    /// that changes will be visible right away.
     ///
-    ///	A pre-requisite is that LE is already enabled, otherwise this
-    ///	command will return a "rejected" response.
+    /// A pre-requisite is that LE is already enabled, otherwise this
+    /// command will return a "rejected" response.
     ///
-    ///	This command can be used when the controller is not powered and
-    ///	all settings will be programmed once powered.
+    /// This command can be used when the controller is not powered and
+    /// all settings will be programmed once powered.
     pub async fn add_advertising(
         &mut self,
         controller: Controller,
@@ -118,26 +118,26 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to remove an advertising instance that
-    ///	can be used to switch a Bluetooth Low Energy controller into
-    ///	advertising mode.
+    /// This command is used to remove an advertising instance that
+    /// can be used to switch a Bluetooth Low Energy controller into
+    /// advertising mode.
     ///
-    ///	When the `instance` parameter is zero, then all previously added
-    ///	advertising Instances will be removed.
+    /// When the `instance` parameter is zero, then all previously added
+    /// advertising Instances will be removed.
     ///
-    ///	Removing advertising information with this command will not be
-    ///	visible as long as advertising is enabled via the Set Advertising
-    ///	command. The usage of the Set Advertising command takes precedence
-    ///	over this command. Changes to Instance information are stored and
-    ///	will be advertised once advertising via Set Advertising has been
-    ///	disabled.
+    /// Removing advertising information with this command will not be
+    /// visible as long as advertising is enabled via the Set Advertising
+    /// command. The usage of the Set Advertising command takes precedence
+    /// over this command. Changes to Instance information are stored and
+    /// will be advertised once advertising via Set Advertising has been
+    /// disabled.
     ///
-    ///	Removing an instance while it is being advertised will immediately
-    ///	cancel the instance, even when it has been advertised less then its
-    ///	configured Timeout or Duration.
+    /// Removing an instance while it is being advertised will immediately
+    /// cancel the instance, even when it has been advertised less then its
+    /// configured Timeout or Duration.
     ///
-    ///	This command can be used when the controller is not powered and
-    ///	all settings will be programmed once powered.
+    /// This command can be used when the controller is not powered and
+    /// all settings will be programmed once powered.
     pub async fn remove_advertising(&mut self, controller: Controller, instance: u8) -> Result<u8> {
         let mut param = BytesMut::with_capacity(1);
         param.put_u8(instance);
@@ -151,19 +151,19 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	The Read Advertising Features command returns the overall maximum
-    ///	size of advertising data and scan response data fields. That size is
-    ///	valid when no Flags are used. However when certain Flags are used,
-    ///	then the size might decrease. This command can be used to request
-    ///	detailed information about the maximum available size.
+    /// The Read Advertising Features command returns the overall maximum
+    /// size of advertising data and scan response data fields. That size is
+    /// valid when no Flags are used. However when certain Flags are used,
+    /// then the size might decrease. This command can be used to request
+    /// detailed information about the maximum available size.
     ///
-    ///	To get accurate information about the available size, the same `flags`
-    ///	values should be used with the Add Advertising command.
+    /// To get accurate information about the available size, the same `flags`
+    /// values should be used with the Add Advertising command.
     ///
-    ///	The `max_adv_data_len` and `max_scan_rsp_len` fields provide information
-    ///	about the maximum length of the data fields for the given `flags`
-    ///	values. When the `flags` field is zero, then these fields would contain
-    ///	the same values as Read Advertising Features.
+    /// The `max_adv_data_len` and `max_scan_rsp_len` fields provide information
+    /// about the maximum length of the data fields for the given `flags`
+    /// values. When the `flags` field is zero, then these fields would contain
+    /// the same values as Read Advertising Features.
     pub async fn get_advertising_size(
         &mut self,
         controller: Controller,
@@ -208,43 +208,43 @@ pub struct AdvertisingSizeInfo {
 pub struct AdvertisingParams {
     pub instance: u8,
 
-    ///	When the `EnterConnectable` flag is not set, then the controller will
-    ///	use advertising based on the connectable setting. When using
-    ///	non-connectable or scannable advertising, the controller will
-    ///	be programmed with a non-resolvable random address. When the
-    ///	system is connectable, then the identity address or resolvable
-    ///	private address will be used.
+    /// When the `EnterConnectable` flag is not set, then the controller will
+    /// use advertising based on the connectable setting. When using
+    /// non-connectable or scannable advertising, the controller will
+    /// be programmed with a non-resolvable random address. When the
+    /// system is connectable, then the identity address or resolvable
+    /// private address will be used.
     ///
-    ///	Using the `EnterConnectable` flag is useful for peripheral mode support
-    ///	where BR/EDR (and/or LE) is controlled by Add Device. This allows
-    ///	making the peripheral connectable without having to interfere
-    ///	with the global connectable setting.
+    /// Using the `EnterConnectable` flag is useful for peripheral mode support
+    /// where BR/EDR (and/or LE) is controlled by Add Device. This allows
+    /// making the peripheral connectable without having to interfere
+    /// with the global connectable setting.
     pub flags: BitFlags<AdvertisingFlags>,
 
     /// Configures the length of an Instance. The
-    ///	value is in seconds.
+    /// value is in seconds.
     ///
-    ///	A value of 0 indicates a default value is chosen for the
-    ///	`duration`. The default is 2 seconds.
+    /// A value of 0 indicates a default value is chosen for the
+    /// `duration`. The default is 2 seconds.
     pub duration: u16,
 
     /// Configures the life-time of an Instance. In
-    ///	case the value 0 is used it indicates no expiration time. If a
-    ///	timeout value is provided, then the advertising Instance will be
-    ///	automatically removed when the timeout passes. The value for the
-    ///	timeout is in seconds. Powering down a controller will invalidate
-    ///	all advertising Instances and it is not possible to add a new
-    ///	Instance with a timeout when the controller is powered down.
+    /// case the value 0 is used it indicates no expiration time. If a
+    /// timeout value is provided, then the advertising Instance will be
+    /// automatically removed when the timeout passes. The value for the
+    /// timeout is in seconds. Powering down a controller will invalidate
+    /// all advertising Instances and it is not possible to add a new
+    /// Instance with a timeout when the controller is powered down.
     pub timeout: u16,
     pub adv_data: Vec<u8>,
 
-    ///	If `scan_rsp` is empty and connectable flag is not set and
-    ///	the global connectable setting is off, then non-connectable
-    ///	advertising is used. If `scan_rsp` is not empty
-    ///	connectable flag is not set and the global advertising is off,
-    ///	then scannable advertising is used. This small difference is
-    ///	supported to provide less air traffic for devices implementing
-    ///	broadcaster role.
+    /// If `scan_rsp` is empty and connectable flag is not set and
+    /// the global connectable setting is off, then non-connectable
+    /// advertising is used. If `scan_rsp` is not empty
+    /// connectable flag is not set and the global advertising is off,
+    /// then scannable advertising is used. This small difference is
+    /// supported to provide less air traffic for devices implementing
+    /// broadcaster role.
     pub scan_rsp: Vec<u8>,
 }
 
@@ -253,58 +253,58 @@ pub struct AdvertisingParams {
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum AdvertisingFlags {
     /// Indicates support for connectable advertising
-    ///	and for switching to connectable advertising independent of the
-    ///	connectable global setting. When this flag is not supported, then
-    ///	the global connectable setting determines if undirected connectable,
-    ///	undirected scannable or undirected non-connectable advertising is
-    ///	used. It also determines the use of non-resolvable random address
-    ///	versus identity address or resolvable private address.
+    /// and for switching to connectable advertising independent of the
+    /// connectable global setting. When this flag is not supported, then
+    /// the global connectable setting determines if undirected connectable,
+    /// undirected scannable or undirected non-connectable advertising is
+    /// used. It also determines the use of non-resolvable random address
+    /// versus identity address or resolvable private address.
     EnterConnectable = 1 << 0,
 
     /// Indicates support for advertising with discoverable
-    ///	mode enabled. Users of this flag will decrease the `max_adv_data_len`
-    ///	by 3. In this case the advertising data flags are managed
-    ///	and added in front of the provided advertising data.
+    /// mode enabled. Users of this flag will decrease the `max_adv_data_len`
+    /// by 3. In this case the advertising data flags are managed
+    /// and added in front of the provided advertising data.
     AdvertiseDiscoverable = 1 << 1,
 
     /// Indicates support for advertising with limited
-    ///	discoverable mode enabled. Users of this flag will decrease the
-    ///	`max_adv_data_len` by 3. In this case the advertising data
-    ///	flags are managed and added in front of the provided advertising
-    ///	data.
+    /// discoverable mode enabled. Users of this flag will decrease the
+    /// `max_adv_data_len` by 3. In this case the advertising data
+    /// flags are managed and added in front of the provided advertising
+    /// data.
     AdvertiseLimitedDiscoverable = 1 << 2,
 
     /// Indicates support for automatically keeping the
-    ///	Flags field of the advertising data updated. Users of this flag
-    ///	will decrease the `max_adv_data_len` by 3 and need to keep
-    ///	that in mind. The Flags field will be added in front of the
-    ///	advertising data provided by the user. Note that with `AdvertiseDiscoverable`
+    /// Flags field of the advertising data updated. Users of this flag
+    /// will decrease the `max_adv_data_len` by 3 and need to keep
+    /// that in mind. The Flags field will be added in front of the
+    /// advertising data provided by the user. Note that with `AdvertiseDiscoverable`
     /// and `AdvertiseLimitedDiscoverable`, this one will be implicitly used even if it is
-    ///	not marked as supported.
+    /// not marked as supported.
     AutoUpdateFlags = 1 << 3,
 
     /// Indicates support for automatically adding the
-    ///	TX Power value to the advertising data. Users of this flag will
-    ///	decrease the `max_adv_data_len` by 3. The `tx_power` field will
-    ///	be added at the end of the user provided advertising data. If the
-    ///	controller does not support TX Power information, then this bit will
-    ///	not be set.
+    /// TX Power value to the advertising data. Users of this flag will
+    /// decrease the `max_adv_data_len` by 3. The `tx_power` field will
+    /// be added at the end of the user provided advertising data. If the
+    /// controller does not support TX Power information, then this bit will
+    /// not be set.
     AutoUpdateTxPower = 1 << 4,
 
     /// indicates support for automatically adding the
-    ///	Appearance value to the scan response data. Users of this flag
-    ///	will decrease the `max_scan_rsp_len` by 4. The `appearance`
-    ///	field will be added in front of the scan response data provided
-    ///	by the user. If the appearance value is not supported, then this
-    ///	bit will not be set.
+    /// Appearance value to the scan response data. Users of this flag
+    /// will decrease the `max_scan_rsp_len` by 4. The `appearance`
+    /// field will be added in front of the scan response data provided
+    /// by the user. If the appearance value is not supported, then this
+    /// bit will not be set.
     AutoUpdateAppearance = 1 << 5,
 
     /// Indicates support for automatically adding the
-    ///	Local Name value to the scan response data. This flag indicates
-    ///	an opportunistic approach for the Local Name. If enough space
-    ///	in the scan response data is available, it will be added. If the
-    ///	space is limited a short version or no name information. The
-    ///	Local Name will be added at the end of the scan response data.
+    /// Local Name value to the scan response data. This flag indicates
+    /// an opportunistic approach for the Local Name. If enough space
+    /// in the scan response data is available, it will be added. If the
+    /// space is limited a short version or no name information. The
+    /// Local Name will be added at the end of the scan response data.
     AutoUpdateLocalName = 1 << 6,
 
     /// Indicates support for advertising in secondary channel in LE 1M PHY.

--- a/src/management/client/advertising.rs
+++ b/src/management/client/advertising.rs
@@ -18,7 +18,7 @@ impl<'a> ManagementClient<'a> {
             controller,
             None,
             |_, param| {
-                let mut param = param.unwrap();
+                let mut param = param.ok_or(Error::NoData)?;
                 Ok(AdvertisingFeaturesInfo {
                     supported_flags: param.get_flags_u32_le(),
                     max_adv_data_len: param.get_u8(),
@@ -113,7 +113,7 @@ impl<'a> ManagementClient<'a> {
             Command::AddAdvertising,
             controller,
             Some(param.freeze()),
-            |_, param| Ok(param.unwrap().get_u8()),
+            |_, param| Ok(param.ok_or(Error::NoData)?.get_u8()),
         )
         .await
     }
@@ -146,7 +146,7 @@ impl<'a> ManagementClient<'a> {
             Command::RemoveAdvertising,
             controller,
             Some(param.freeze()),
-            |_, param| Ok(param.unwrap().get_u8()),
+            |_, param| Ok(param.ok_or(Error::NoData)?.get_u8()),
         )
         .await
     }
@@ -177,7 +177,7 @@ impl<'a> ManagementClient<'a> {
             controller,
             Some(param.freeze()),
             |_, param| {
-                let mut param = param.unwrap();
+                let mut param = param.ok_or(Error::NoData)?;
                 Ok(AdvertisingSizeInfo {
                     instance: param.get_u8(),
                     flags: param.get_flags_u32_le(),

--- a/src/management/client/advertising.rs
+++ b/src/management/client/advertising.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::util::BufExtBlueZ;
-use enumflags2::{BitFlags, bitflags};
+use enumflags2::{bitflags, BitFlags};
 
 impl<'a> ManagementClient<'a> {
     /// This command is used to read the advertising features supported

--- a/src/management/client/class.rs
+++ b/src/management/client/class.rs
@@ -28,7 +28,7 @@ impl<'a> ManagementClient<'a> {
             Command::SetDeviceClass,
             controller,
             Some(param.freeze()),
-            |_, param| Ok(device_class_from_bytes(param.unwrap())),
+            |_, param| Ok(device_class_from_bytes(param.ok_or(Error::NoData)?)),
         )
         .await
     }
@@ -58,7 +58,7 @@ impl<'a> ManagementClient<'a> {
             Command::AddUUID,
             controller,
             Some(param.freeze()),
-            |_, param| Ok(device_class_from_bytes(param.unwrap())),
+            |_, param| Ok(device_class_from_bytes(param.ok_or(Error::NoData)?)),
         )
         .await
     }
@@ -86,7 +86,7 @@ impl<'a> ManagementClient<'a> {
             Command::RemoveUUID,
             controller,
             Some(param.freeze()),
-            |_, param| Ok(device_class_from_bytes(param.unwrap())),
+            |_, param| Ok(device_class_from_bytes(param.ok_or(Error::NoData)?)),
         )
         .await
     }

--- a/src/management/client/class.rs
+++ b/src/management/client/class.rs
@@ -2,20 +2,20 @@ use super::*;
 
 impl<'a> ManagementClient<'a> {
     /// This command is used to set the major and minor device class for
-    ///	BR/EDR capable controllers.
+    /// BR/EDR capable controllers.
     ///
-    ///	This command will also implicitly disable caching of pending CoD
-    ///	and EIR updates.
+    /// This command will also implicitly disable caching of pending CoD
+    /// and EIR updates.
     ///
-    ///	This command is only available for BR/EDR capable controllers
-    ///	(e.g. not for single-mode LE ones).
+    /// This command is only available for BR/EDR capable controllers
+    /// (e.g. not for single-mode LE ones).
     ///
-    ///	This command can be used when the controller is not powered and
-    ///	all settings will be programmed once powered.
+    /// This command can be used when the controller is not powered and
+    /// all settings will be programmed once powered.
     ///
-    ///	In case the controller is powered off, Unknown will be returned
-    ///	for the class of device parameter. And after power on the new
-    ///	value will be announced via class of device changed event.
+    /// In case the controller is powered off, Unknown will be returned
+    /// for the class of device parameter. And after power on the new
+    /// value will be announced via class of device changed event.
     pub async fn set_device_class(
         &mut self,
         controller: Controller,
@@ -33,17 +33,17 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to add a UUID to be published in EIR data.
-    ///	The accompanied SVC_Hint parameter is used to tell the kernel
-    ///	whether the service class bits of the Class of Device value need
-    ///	modifying due to this UUID.
+    /// This command is used to add a UUID to be published in EIR data.
+    /// The accompanied SVC_Hint parameter is used to tell the kernel
+    /// whether the service class bits of the Class of Device value need
+    /// modifying due to this UUID.
     ///
-    ///	This command can be used when the controller is not powered and
-    ///	all settings will be programmed once powered.
+    /// This command can be used when the controller is not powered and
+    /// all settings will be programmed once powered.
     ///
-    ///	In case the controller is powered off, `0x000000` will be returned
-    ///	for the class of device parameter. And after power on the new
-    ///	value will be announced via class of device changed event.
+    /// In case the controller is powered off, `0x000000` will be returned
+    /// for the class of device parameter. And after power on the new
+    /// value will be announced via class of device changed event.
     pub async fn add_uuid(
         &mut self,
         controller: Controller,
@@ -63,18 +63,18 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to remove a UUID previously added using the
-    ///	Add UUID command.
+    /// This command is used to remove a UUID previously added using the
+    /// Add UUID command.
     ///
-    ///	When the UUID parameter is an empty UUID (16 x `0x00`), then all
-    ///	previously loaded UUIDs will be removed.
+    /// When the UUID parameter is an empty UUID (16 x `0x00`), then all
+    /// previously loaded UUIDs will be removed.
     ///
-    ///	This command can be used when the controller is not powered and
-    ///	all settings will be programmed once powered.
+    /// This command can be used when the controller is not powered and
+    /// all settings will be programmed once powered.
     ///
-    ///	In case the controller is powered off, `0x000000` will be returned
-    ///	for the class of device parameter. And after power on the new
-    ///	value will be announced via class of device changed event.
+    /// In case the controller is powered off, `0x000000` will be returned
+    /// for the class of device parameter. And after power on the new
+    /// value will be announced via class of device changed event.
     pub async fn remove_uuid(
         &mut self,
         controller: Controller,

--- a/src/management/client/discovery.rs
+++ b/src/management/client/discovery.rs
@@ -34,7 +34,7 @@ impl<'a> ManagementClient<'a> {
             Command::StartDiscovery,
             controller,
             Some(param.freeze()),
-            |_, param| Ok(param.unwrap().get_flags_u8()),
+            |_, param| Ok(param.ok_or(Error::NoData)?.get_flags_u8()),
         )
         .await
     }
@@ -55,7 +55,7 @@ impl<'a> ManagementClient<'a> {
             Command::StopDiscovery,
             controller,
             Some(param.freeze()),
-            |_, param| Ok(param.unwrap().get_flags_u8()),
+            |_, param| Ok(param.ok_or(Error::NoData)?.get_flags_u8()),
         )
         .await
     }
@@ -103,7 +103,7 @@ impl<'a> ManagementClient<'a> {
             Command::StartServiceDiscovery,
             controller,
             Some(param.freeze()),
-            |_, param| Ok(param.unwrap().get_flags_u8()),
+            |_, param| Ok(param.ok_or(Error::NoData)?.get_flags_u8()),
         )
         .await
     }
@@ -133,7 +133,7 @@ impl<'a> ManagementClient<'a> {
             Command::StartLimitedDiscovery,
             controller,
             Some(param.freeze()),
-            |_, param| Ok(param.unwrap().get_flags_u8()),
+            |_, param| Ok(param.ok_or(Error::NoData)?.get_flags_u8()),
         )
         .await
     }

--- a/src/management/client/discovery.rs
+++ b/src/management/client/discovery.rs
@@ -4,24 +4,24 @@ use super::*;
 use crate::util::BufExtBlueZ;
 
 impl<'a> ManagementClient<'a> {
-    ///	This command is used to start the process of discovering remote
-    ///	devices. A Device Found event will be sent for each discovered
-    ///	device.
+    /// This command is used to start the process of discovering remote
+    /// devices. A Device Found event will be sent for each discovered
+    /// device.
     ///
-    ///	Possible values for the `address_type` parameter are a bit-wise or
-    ///	of the following bits:
+    /// Possible values for the `address_type` parameter are a bit-wise or
+    /// of the following bits:
     ///
-    ///	0	BR/EDR
-    ///	1	LE Public
-    ///	2	LE Random
+    /// 0 BR/EDR
+    /// 1 LE Public
+    /// 2 LE Random
     ///
-    ///	By combining these e.g. the following values are possible:
+    /// By combining these e.g. the following values are possible:
     ///
-    ///	1	BR/EDR
-    ///	6	LE (public & random)
-    ///	7	BR/EDR/LE (interleaved discovery)
+    /// 1 BR/EDR
+    /// 6 LE (public & random)
+    /// 7 BR/EDR/LE (interleaved discovery)
     ///
-    ///	This command can only be used when the controller is powered.
+    /// This command can only be used when the controller is powered.
     pub async fn start_discovery(
         &mut self,
         controller: Controller,
@@ -40,9 +40,9 @@ impl<'a> ManagementClient<'a> {
     }
 
     /// This command is used to stop the discovery process started using
-    ///	the Start Discovery command.
+    /// the Start Discovery command.
     ///
-    ///	This command can only be used when the controller is powered.
+    /// This command can only be used when the controller is powered.
     pub async fn stop_discovery(
         &mut self,
         controller: Controller,
@@ -60,29 +60,29 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to start the process of discovering remote
-    ///	devices with a specific UUID. A Device Found event will be sent
-    ///	for each discovered device.
+    /// This command is used to start the process of discovering remote
+    /// devices with a specific UUID. A Device Found event will be sent
+    /// for each discovered device.
     ///
     ///  The service discovery uses active scanning for Low Energy scanning
-    ///	and will search for UUID in both advertising data and scan response
-    ///	data.
+    /// and will search for UUID in both advertising data and scan response
+    /// data.
     ///
-    ///	Found devices that have a RSSI value smaller than `rssi_threshold`
-    ///	are not reported via DeviceFound event. Setting a value of 127
-    ///	will cause all devices to be reported.
+    /// Found devices that have a RSSI value smaller than `rssi_threshold`
+    /// are not reported via DeviceFound event. Setting a value of 127
+    /// will cause all devices to be reported.
     ///
-    ///	The list of UUIDs identifies a logical OR. Only one of the UUIDs
-    ///	have to match to cause a DeviceFound event. Providing an empty
-    ///	list of UUIDs means that DeviceFound events are send out for all devices above the RSSI_Threshold.
+    /// The list of UUIDs identifies a logical OR. Only one of the UUIDs
+    /// have to match to cause a DeviceFound event. Providing an empty
+    /// list of UUIDs means that DeviceFound events are send out for all devices above the RSSI_Threshold.
     ///
-    ///	In case `rssi_threshold` is set to 127 and `uuids` is empty, then
-    ///	this command behaves exactly the same as Start Discovery.
+    /// In case `rssi_threshold` is set to 127 and `uuids` is empty, then
+    /// this command behaves exactly the same as Start Discovery.
     ///
-    ///	When the discovery procedure starts the Discovery event will
-    ///	notify this similar to Start Discovery.
+    /// When the discovery procedure starts the Discovery event will
+    /// notify this similar to Start Discovery.
     ///
-    ///	This command can only be used when the controller is powered.
+    /// This command can only be used when the controller is powered.
     pub async fn start_service_discovery(
         &mut self,
         controller: Controller,
@@ -108,19 +108,19 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to start the process of discovering remote
-    ///	devices using the limited discovery procedure. A Device Found event
-    ///	will be sent for each discovered device.
+    /// This command is used to start the process of discovering remote
+    /// devices using the limited discovery procedure. A Device Found event
+    /// will be sent for each discovered device.
     ///
-    ///	The limited discovery uses active scanning for Low Energy scanning
-    ///	and will search for devices with the limited discoverability flag
-    ///	configured. On BR/EDR it uses LIAC and filters on the limited
-    ///	discoverability flag of the class of device.
+    /// The limited discovery uses active scanning for Low Energy scanning
+    /// and will search for devices with the limited discoverability flag
+    /// configured. On BR/EDR it uses LIAC and filters on the limited
+    /// discoverability flag of the class of device.
     ///
-    ///	When the discovery procedure starts the Discovery event will
-    ///	notify this similar to Start Discovery.
+    /// When the discovery procedure starts the Discovery event will
+    /// notify this similar to Start Discovery.
     ///
-    ///	This command can only be used when the controller is powered.
+    /// This command can only be used when the controller is powered.
     pub async fn start_limited_discovery(
         &mut self,
         controller: Controller,

--- a/src/management/client/interact.rs
+++ b/src/management/client/interact.rs
@@ -29,16 +29,16 @@ pub(crate) fn address_bytes_with_u8(
 }
 
 impl<'a> ManagementClient<'a> {
-    ///	This command is only valid during device discovery and is
-    ///	expected for each Device Found event with the Confirm Name
-    ///	flag set.
+    /// This command is only valid during device discovery and is
+    /// expected for each Device Found event with the Confirm Name
+    /// flag set.
     ///
-    ///	The name_known parameter should be set to true if user space
-    ///	knows the name for the device and false if it doesn't. If set to
-    ///	false the kernel will perform a name resolving procedure for the
-    ///	device in question.
+    /// The name_known parameter should be set to true if user space
+    /// knows the name for the device and false if it doesn't. If set to
+    /// false the kernel will perform a name resolving procedure for the
+    /// device in question.
     ///
-    ///	This command can only be used when the controller is powered.
+    /// This command can only be used when the controller is powered.
     pub async fn confirm_name(
         &mut self,
         controller: Controller,
@@ -60,19 +60,19 @@ impl<'a> ManagementClient<'a> {
     }
 
     /// This command is used to add a device to the list of devices
-    ///	which should be blocked from being connected to the local
-    ///	controller.
+    /// which should be blocked from being connected to the local
+    /// controller.
     ///
-    ///	For Low Energy devices, the blocking of a device takes precedence
-    ///	over auto-connection actions provided by Add Device. Blocked
-    ///	devices will not be auto-connected or even reported when found
-    ///	during background scanning. If the controller is connectable
-    ///	direct advertising from blocked devices will also be ignored.
+    /// For Low Energy devices, the blocking of a device takes precedence
+    /// over auto-connection actions provided by Add Device. Blocked
+    /// devices will not be auto-connected or even reported when found
+    /// during background scanning. If the controller is connectable
+    /// direct advertising from blocked devices will also be ignored.
     ///
-    ///	Connections created from advertising of the controller will
-    ///	be dropped if the device is blocked.
+    /// Connections created from advertising of the controller will
+    /// be dropped if the device is blocked.
     ///
-    ///	This command can be used when the controller is not powered.
+    /// This command can be used when the controller is not powered.
     pub async fn block_device(
         &mut self,
         controller: Controller,
@@ -89,12 +89,12 @@ impl<'a> ManagementClient<'a> {
     }
 
     /// This command is used to remove a device from the list of blocked
-    ///	devices (where it was added to using the Block Device command).
+    /// devices (where it was added to using the Block Device command).
     ///
-    ///	When the `address` parameter is `00:00:00:00:00:00`, then all
-    ///	previously blocked devices will be unblocked.
+    /// When the `address` parameter is `00:00:00:00:00:00`, then all
+    /// previously blocked devices will be unblocked.
     ///
-    ///	This command can be used when the controller is not powered.
+    /// This command can be used when the controller is not powered.
     pub async fn unblock_device(
         &mut self,
         controller: Controller,
@@ -110,10 +110,10 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to force the disconnection of a currently
-    ///	connected device.
+    /// This command is used to force the disconnection of a currently
+    /// connected device.
     ///
-    ///	This command can only be used when the controller is powered.
+    /// This command can only be used when the controller is powered.
     pub async fn disconnect(
         &mut self,
         controller: Controller,
@@ -129,10 +129,10 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to respond to a PIN Code request event.
+    /// This command is used to respond to a PIN Code request event.
     /// Pin code can be at most 16 bytes. Passing None will send a
     /// negative PIN code response.
-    ///	This command can only be used when the controller is powered.
+    /// This command can only be used when the controller is powered.
     pub async fn pin_code_reply(
         &mut self,
         controller: Controller,
@@ -162,27 +162,27 @@ impl<'a> ManagementClient<'a> {
             .await
     }
 
-    ///	This command is used to trigger pairing with a remote device.
-    ///	The IO_Capability command parameter is used to temporarily (for
-    ///	this pairing event only) override the global IO Capability (set
-    ///	using the Set IO Capability command).
+    /// This command is used to trigger pairing with a remote device.
+    /// The IO_Capability command parameter is used to temporarily (for
+    /// this pairing event only) override the global IO Capability (set
+    /// using the Set IO Capability command).
     ///
-    ///	Passing a value 4 (KeyboardDisplay) will cause the kernel to
-    ///	convert it to 1 (DisplayYesNo) in the case of a BR/EDR
-    ///	connection (as KeyboardDisplay is specific to SMP).
+    /// Passing a value 4 (KeyboardDisplay) will cause the kernel to
+    /// convert it to 1 (DisplayYesNo) in the case of a BR/EDR
+    /// connection (as KeyboardDisplay is specific to SMP).
     ///
-    ///	The `address` and `address_type` of the return parameters will
-    ///	return the identity address if known. In case of resolvable
-    ///	random address given as command parameters and the remote
-    ///	provides an identity resolving key, the return parameters
-    ///	will provide the resolved address.
+    /// The `address` and `address_type` of the return parameters will
+    /// return the identity address if known. In case of resolvable
+    /// random address given as command parameters and the remote
+    /// provides an identity resolving key, the return parameters
+    /// will provide the resolved address.
     ///
-    ///	To allow tracking of which resolvable random address changed
-    ///	into which identity address, the New Identity Resolving Key
-    ///	event will be sent before receiving Command Complete event
-    ///	for this command.
+    /// To allow tracking of which resolvable random address changed
+    /// into which identity address, the New Identity Resolving Key
+    /// event will be sent before receiving Command Complete event
+    /// for this command.
     ///
-    ///	This command can only be used when the controller is powered.
+    /// This command can only be used when the controller is powered.
     pub async fn pair_device(
         &mut self,
         controller: Controller,
@@ -203,10 +203,10 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	The `address` and `address_type` parameters should match what was
-    ///	given to a preceding Pair Device command.
+    /// The `address` and `address_type` parameters should match what was
+    /// given to a preceding Pair Device command.
     ///
-    ///	This command can only be used when the controller is powered.
+    /// This command can only be used when the controller is powered.
     pub async fn cancel_pair_device(
         &mut self,
         controller: Controller,
@@ -222,22 +222,22 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	Removes all keys associated with the remote device.
+    /// Removes all keys associated with the remote device.
     ///
-    ///	The disconnect parameter tells the kernel whether to forcefully
-    ///	disconnect any existing connections to the device. It should in
-    ///	practice always be true except for some special GAP qualification
-    ///	test-cases where a key removal without disconnecting is needed.
+    /// The disconnect parameter tells the kernel whether to forcefully
+    /// disconnect any existing connections to the device. It should in
+    /// practice always be true except for some special GAP qualification
+    /// test-cases where a key removal without disconnecting is needed.
     ///
-    ///	When unpairing a device its link key, long term key and if
-    ///	provided identity resolving key will be purged.
+    /// When unpairing a device its link key, long term key and if
+    /// provided identity resolving key will be purged.
     ///
-    ///	For devices using resolvable random addresses where the identity
-    ///	resolving key was available, after this command they will now no
-    ///	longer be resolved. The device will essentially become private
-    ///	again.
+    /// For devices using resolvable random addresses where the identity
+    /// resolving key was available, after this command they will now no
+    /// longer be resolved. The device will essentially become private
+    /// again.
     ///
-    ///	This command can only be used when the controller is powered.
+    /// This command can only be used when the controller is powered.
     pub async fn unpair_device(
         &mut self,
         controller: Controller,
@@ -258,8 +258,8 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to respond to a User Confirmation Request
-    ///	event. This command can only be used when the controller is powered.
+    /// This command is used to respond to a User Confirmation Request
+    /// event. This command can only be used when the controller is powered.
     pub async fn user_confirmation_reply(
         &mut self,
         controller: Controller,
@@ -280,8 +280,8 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to respond to a User Passkey Request
-    ///	event. Passing None for passkey will send a negative response.
+    /// This command is used to respond to a User Passkey Request
+    /// event. Passing None for passkey will send a negative response.
     /// This command can only be used when the controller is powered.
     pub async fn user_passkey_reply(
         &mut self,
@@ -310,34 +310,34 @@ impl<'a> ManagementClient<'a> {
             .await
     }
 
-    ///	This command is used to add a device to the action list. The
-    ///	action list allows scanning for devices and enables incoming
-    ///	connections from known devices.
+    /// This command is used to add a device to the action list. The
+    /// action list allows scanning for devices and enables incoming
+    /// connections from known devices.
     ///
-    ///	With the `BackgroundScan` action, when the device is found, a new Device Found
-    ///	event will be sent indicating this device is available. This
-    ///	action is only valid for LE Public and LE Random address types.
+    /// With the `BackgroundScan` action, when the device is found, a new Device Found
+    /// event will be sent indicating this device is available. This
+    /// action is only valid for LE Public and LE Random address types.
     ///
-    ///	With the `AllowConnect` action, the device is allowed to connect. For BR/EDR
-    ///	address type this means an incoming connection. For LE Public
-    ///	and LE Random address types, a connection will be established
-    ///	to devices using directed advertising. If successful a Device
-    ///	Connected event will be sent.
+    /// With the `AllowConnect` action, the device is allowed to connect. For BR/EDR
+    /// address type this means an incoming connection. For LE Public
+    /// and LE Random address types, a connection will be established
+    /// to devices using directed advertising. If successful a Device
+    /// Connected event will be sent.
     ///
-    ///	With the `AutoConnect`, when the device is found, it will be connected
-    ///	and if successful a Device Connected event will be sent. This
-    ///	action is only valid for LE Public and LE Random address types.
+    /// With the `AutoConnect`, when the device is found, it will be connected
+    /// and if successful a Device Connected event will be sent. This
+    /// action is only valid for LE Public and LE Random address types.
     ///
-    ///	When a device is blocked using Block Device command, then it is
-    ///	valid to add the device here, but all actions will be ignored
-    ///	until the device is unblocked.
+    /// When a device is blocked using Block Device command, then it is
+    /// valid to add the device here, but all actions will be ignored
+    /// until the device is unblocked.
     ///
-    ///	Devices added with `AllowConnect` are allowed to connect even if the
-    ///	connectable setting is off. This acts as list of known trusted
-    ///	devices.
+    /// Devices added with `AllowConnect` are allowed to connect even if the
+    /// connectable setting is off. This acts as list of known trusted
+    /// devices.
     ///
-    ///	This command can be used when the controller is not powered and
-    ///	all settings will be programmed once powered.
+    /// This command can be used when the controller is not powered and
+    /// all settings will be programmed once powered.
     pub async fn add_device(
         &mut self,
         controller: Controller,
@@ -354,14 +354,14 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to remove a device from the action list
-    ///	previously added by using the Add Device command.
+    /// This command is used to remove a device from the action list
+    /// previously added by using the Add Device command.
     ///
-    ///	When the Address parameter is `00:00:00:00:00:00`, then all
-    ///	previously added devices will be removed.
+    /// When the Address parameter is `00:00:00:00:00:00`, then all
+    /// previously added devices will be removed.
     ///
-    ///	This command can be used when the controller is not powered and
-    ///	all settings will be programmed once powered.
+    /// This command can be used when the controller is not powered and
+    /// all settings will be programmed once powered.
     pub async fn remove_device(
         &mut self,
         controller: Controller,

--- a/src/management/client/interact.rs
+++ b/src/management/client/interact.rs
@@ -5,7 +5,7 @@ pub(crate) fn address_callback(
     _: Controller,
     param: Option<Bytes>,
 ) -> Result<(Address, AddressType)> {
-    let mut param = param.unwrap();
+    let mut param = param.ok_or(Error::NoData)?;
     Ok((param.get_address(), param.get_primitive_u8()))
 }
 

--- a/src/management/client/load.rs
+++ b/src/management/client/load.rs
@@ -2,20 +2,20 @@ use super::*;
 
 impl<'a> ManagementClient<'a> {
     /// This command is used to feed the kernel with currently known
-    ///	link keys. The command does not need to be called again upon the
-    ///	receipt of New Link Key events since the kernel updates its list
-    ///	automatically.
+    /// link keys. The command does not need to be called again upon the
+    /// receipt of New Link Key events since the kernel updates its list
+    /// automatically.
     ///
-    ///	The debug parameter is used to tell the kernel whether to
-    ///	accept the usage of debug keys or not. The allowed values for
-    ///	this parameter are `0x00` and `0x01`. All other values will return
-    ///	an Invalid Parameters response.
+    /// The debug parameter is used to tell the kernel whether to
+    /// accept the usage of debug keys or not. The allowed values for
+    /// this parameter are `0x00` and `0x01`. All other values will return
+    /// an Invalid Parameters response.
     ///
-    ///	Usage of the debug parameter is deprecated and has been
-    ///	replaced with the Set Debug Keys command. When setting the
-    ///	debug option via Load Link Keys command it has the same
-    ///	affect as setting it via Set Debug Keys and applies to all
-    ///	keys in the system.
+    /// Usage of the debug parameter is deprecated and has been
+    /// replaced with the Set Debug Keys command. When setting the
+    /// debug option via Load Link Keys command it has the same
+    /// affect as setting it via Set Debug Keys and applies to all
+    /// keys in the system.
     pub async fn load_link_keys(
         &mut self,
         controller: Controller,
@@ -43,18 +43,18 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to feed the kernel with currently known
-    ///	(SMP) Long Term Keys. The command does not need to be called
-    ///	again upon the receipt of New Long Term Key events since the
-    ///	kernel updates its list automatically.
+    /// This command is used to feed the kernel with currently known
+    /// (SMP) Long Term Keys. The command does not need to be called
+    /// again upon the receipt of New Long Term Key events since the
+    /// kernel updates its list automatically.
     ///
-    ///	The provided address and address_type are the identity of
-    ///	a device. So either its public address or static random address.
+    /// The provided address and address_type are the identity of
+    /// a device. So either its public address or static random address.
     ///
-    ///	Unresolvable random addresses and resolvable random addresses are
-    ///	not valid and will be rejected.
+    /// Unresolvable random addresses and resolvable random addresses are
+    /// not valid and will be rejected.
     ///
-    ///	This command can be used when the controller is not powered.
+    /// This command can be used when the controller is not powered.
     pub async fn load_long_term_keys(
         &mut self,
         controller: Controller,
@@ -83,18 +83,18 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to feed the kernel with currently known
-    ///	identity resolving keys. The command does not need to be called
-    ///	again upon the receipt of New Identity Resolving Key events
-    ///	since the kernel updates its list automatically.
+    /// This command is used to feed the kernel with currently known
+    /// identity resolving keys. The command does not need to be called
+    /// again upon the receipt of New Identity Resolving Key events
+    /// since the kernel updates its list automatically.
     ///
-    ///	The provided `address` and `address_type` are the identity of
-    ///	a device. So either its public address or static random address.
+    /// The provided `address` and `address_type` are the identity of
+    /// a device. So either its public address or static random address.
     ///
-    ///	Unresolvable random addresses and resolvable random addresses are
-    ///	not valid and will be rejected.
+    /// Unresolvable random addresses and resolvable random addresses are
+    /// not valid and will be rejected.
     ///
-    ///	This command can be used when the controller is not powered.
+    /// This command can be used when the controller is not powered.
     pub async fn load_identity_resolving_keys(
         &mut self,
         controller: Controller,
@@ -118,18 +118,18 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to load connection parameters from several
-    ///	devices into kernel. Currently this is only supported on controllers
-    ///	with Low Energy support.
+    /// This command is used to load connection parameters from several
+    /// devices into kernel. Currently this is only supported on controllers
+    /// with Low Energy support.
     ///
-    ///	The provided Address and Address_Type are the identity of
-    ///	a device. So either its public address or static random address.
+    /// The provided Address and Address_Type are the identity of
+    /// a device. So either its public address or static random address.
     ///
-    ///	The `min_connection_interval`, `max_connection_interval`,
-    ///	`connection_latency` and `supervision_timeout` parameters should
-    ///	be configured as described in Core 4.1 spec, Vol 2, 7.8.12.
+    /// The `min_connection_interval`, `max_connection_interval`,
+    /// `connection_latency` and `supervision_timeout` parameters should
+    /// be configured as described in Core 4.1 spec, Vol 2, 7.8.12.
     ///
-    ///	This command can be used when the controller is not powered.
+    /// This command can be used when the controller is not powered.
     pub async fn load_connection_parameters(
         &mut self,
         controller: Controller,
@@ -157,10 +157,10 @@ impl<'a> ManagementClient<'a> {
     }
 
     /// This command is used to feed the kernel a list of keys that
-    ///	are known to be vulnerable.
+    /// are known to be vulnerable.
     ///
-    ///	If the pairing procedure produces any of these keys, they will be
-    ///	silently dropped and any attempt to enable encryption rejected.
+    /// If the pairing procedure produces any of these keys, they will be
+    /// silently dropped and any attempt to enable encryption rejected.
     ///
     /// This command can be used when the controller is not powered.
     pub async fn load_blocked_keys(

--- a/src/management/client/mod.rs
+++ b/src/management/client/mod.rs
@@ -28,7 +28,7 @@ pub struct ManagementClient<'a> {
     handler: Option<ManagementEventHandler<'a>>,
 }
 
-pub type ManagementEventHandler<'a> = Box<dyn (FnMut(Controller, &Event) -> ()) + Send + 'a>;
+pub type ManagementEventHandler<'a> = Box<dyn (FnMut(Controller, &Event)) + Send + 'a>;
 
 impl<'a> ManagementClient<'a> {
     pub fn new() -> Result<Self> {

--- a/src/management/client/mod.rs
+++ b/src/management/client/mod.rs
@@ -81,7 +81,7 @@ impl<'a> ManagementClient<'a> {
         param: Option<Bytes>,
         callback: F,
     ) -> Result<T> {
-        let param = param.unwrap_or(Bytes::new());
+        let param = param.unwrap_or_default();
 
         // send request
         self.socket

--- a/src/management/client/oob.rs
+++ b/src/management/client/oob.rs
@@ -7,15 +7,15 @@ use crate::util::BufExtBlueZ;
 impl<'a> ManagementClient<'a> {
     /// This command is used to read the local Out of Band data.
     ///
-    ///	This command can only be used when the controller is powered.
+    /// This command can only be used when the controller is powered.
     ///
-    ///	If Secure Connections support is enabled, then this command
-    ///	will return P-192 versions of hash and randomizer as well as
-    ///	P-256 versions of both.
+    /// If Secure Connections support is enabled, then this command
+    /// will return P-192 versions of hash and randomizer as well as
+    /// P-256 versions of both.
     ///
-    ///	Values returned by this command become invalid when the controller
-    ///	is powered down. After each power-cycle it is required to call
-    ///	this command again to get updated values.
+    /// Values returned by this command become invalid when the controller
+    /// is powered down. After each power-cycle it is required to call
+    /// this command again to get updated values.
     pub async fn read_local_oob_data(&mut self, controller: Controller) -> Result<OutOfBandData> {
         self.exec_command(Command::ReadLocalOutOfBand, controller, None, |_, param| {
             let mut param = param.unwrap();
@@ -65,39 +65,39 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to provide Out of Band data for a remote
-    ///	device.
+    /// This command is used to provide Out of Band data for a remote
+    /// device.
     ///
-    ///	Provided Out Of Band data is persistent over power down/up toggles.
+    /// Provided Out Of Band data is persistent over power down/up toggles.
     ///
-    ///	This command also accept optional P-256 versions of hash and
-    ///	randomizer. If they are not provided, then they are set to
-    ///	zero value.
+    /// This command also accept optional P-256 versions of hash and
+    /// randomizer. If they are not provided, then they are set to
+    /// zero value.
     ///
-    ///	The P-256 versions of both can also be provided when the
-    ///	support for Secure Connections is not enabled. However in
-    ///	that case they will never be used.
+    /// The P-256 versions of both can also be provided when the
+    /// support for Secure Connections is not enabled. However in
+    /// that case they will never be used.
     ///
-    ///	To only provide the P-256 versions of hash and randomizer,
-    ///	it is valid to leave both P-192 fields as zero values. If
-    ///	Secure Connections is disabled, then of course this is the
-    ///	same as not providing any data at all.
+    /// To only provide the P-256 versions of hash and randomizer,
+    /// it is valid to leave both P-192 fields as zero values. If
+    /// Secure Connections is disabled, then of course this is the
+    /// same as not providing any data at all.
     ///
-    ///	When providing data for remote LE devices, then the Hash_192 and
-    ///	and Randomizer_192 fields are not used and shell be set to zero.
+    /// When providing data for remote LE devices, then the Hash_192 and
+    /// and Randomizer_192 fields are not used and shell be set to zero.
     ///
-    ///	The Hash_256 and Randomizer_256 fields can be used for LE secure
-    ///	connections Out Of Band data. If only LE secure connections data
-    ///	is provided the Hash_P192 and Randomizer_P192 fields can be set
-    ///	to zero. Currently there is no support for providing the Security
-    ///	Manager TK Value for LE legacy pairing.
+    /// The Hash_256 and Randomizer_256 fields can be used for LE secure
+    /// connections Out Of Band data. If only LE secure connections data
+    /// is provided the Hash_P192 and Randomizer_P192 fields can be set
+    /// to zero. Currently there is no support for providing the Security
+    /// Manager TK Value for LE legacy pairing.
     ///
-    ///	If Secure Connections Only mode has been enabled, then providing
-    ///	Hash_P192 and Randomizer_P192 is not allowed. They are required
-    ///	to be set to zero values.
+    /// If Secure Connections Only mode has been enabled, then providing
+    /// Hash_P192 and Randomizer_P192 is not allowed. They are required
+    /// to be set to zero values.
     ///
-    ///	This command can be used when the controller is not powered and
-    ///	all settings will be programmed once powered.
+    /// This command can be used when the controller is not powered and
+    /// all settings will be programmed once powered.
     pub async fn add_remote_oob_data(
         &mut self,
         controller: Controller,
@@ -128,13 +128,13 @@ impl<'a> ManagementClient<'a> {
     }
 
     /// This command is used to remove data added using the Add Remote
-    ///	Out Of Band Data command.
+    /// Out Of Band Data command.
     ///
-    ///	When the `address` parameter is `00:00:00:00:00:00`, then all
-    ///	previously added data will be removed.
+    /// When the `address` parameter is `00:00:00:00:00:00`, then all
+    /// previously added data will be removed.
     ///
-    ///	This command can be used when the controller is not powered and
-    ///	all settings will be programmed once powered.
+    /// This command can be used when the controller is not powered and
+    /// all settings will be programmed once powered.
     pub async fn remove_remote_oob_data(
         &mut self,
         controller: Controller,

--- a/src/management/client/oob.rs
+++ b/src/management/client/oob.rs
@@ -18,7 +18,7 @@ impl<'a> ManagementClient<'a> {
     /// this command again to get updated values.
     pub async fn read_local_oob_data(&mut self, controller: Controller) -> Result<OutOfBandData> {
         self.exec_command(Command::ReadLocalOutOfBand, controller, None, |_, param| {
-            let mut param = param.unwrap();
+            let mut param = param.ok_or(Error::NoData)?;
             Ok(OutOfBandData {
                 hash_192: param.get_u8x16(),
                 randomizer_192: param.get_u8x16(),
@@ -50,7 +50,7 @@ impl<'a> ManagementClient<'a> {
             controller,
             Some(Bytes::copy_from_slice(&[address_types.bits() as u8])),
             |_, param| {
-                let mut param = param.unwrap();
+                let mut param = param.ok_or(Error::NoData)?;
                 Ok((
                     param.get_flags_u8(),
                     // read eir data length param, then use that to split

--- a/src/management/client/query.rs
+++ b/src/management/client/query.rs
@@ -16,7 +16,7 @@ impl<'a> ManagementClient<'a> {
             Controller::none(),
             None,
             |_, param| {
-                let mut param = param.unwrap();
+                let mut param = param.ok_or(Error::NoData)?;
                 Ok(ManagementVersion {
                     version: param.get_u8(),
                     revision: param.get_u16_le(),
@@ -35,7 +35,8 @@ impl<'a> ManagementClient<'a> {
             Controller::none(),
             None,
             |_, param| {
-                let mut param = param.unwrap();
+                let mut param = param.ok_or(Error::NoData)?;
+
                 let count = param.get_u16_le() as usize;
                 let mut controllers = vec![Controller::none(); count];
                 for i in 0..count {
@@ -71,7 +72,7 @@ impl<'a> ManagementClient<'a> {
     /// If no short name is set the Short_Name parameter will be all zeroes.
     pub async fn get_controller_info(&mut self, controller: Controller) -> Result<ControllerInfo> {
         self.exec_command(Command::ReadControllerInfo, controller, None, |_, param| {
-            let mut param = param.unwrap();
+            let mut param = param.ok_or(Error::NoData)?;
 
             Ok(ControllerInfo {
                 address: param.get_address(),
@@ -100,7 +101,7 @@ impl<'a> ManagementClient<'a> {
         controller: Controller,
     ) -> Result<Vec<(Address, AddressType)>> {
         self.exec_command(Command::GetConnections, controller, None, |_, param| {
-            let mut param = param.unwrap();
+            let mut param = param.ok_or(Error::NoData)?;
             let count = param.get_u16_le() as usize;
             let mut connections = Vec::with_capacity(count);
 
@@ -129,7 +130,7 @@ impl<'a> ManagementClient<'a> {
             controller,
             Some(param.freeze()),
             |_, param| {
-                let mut param = param.unwrap();
+                let mut param = param.ok_or(Error::NoData)?;
                 Ok(ConnectionInfo {
                     address: param.get_address(),
                     address_type: param.get_primitive_u8(),
@@ -170,7 +171,7 @@ impl<'a> ManagementClient<'a> {
             controller,
             Some(param.freeze()),
             |_, param| {
-                let mut param = param.unwrap();
+                let mut param = param.ok_or(Error::NoData)?;
 
                 let address = param.get_address();
                 let address_type = param.get_primitive_u8();
@@ -217,7 +218,7 @@ impl<'a> ManagementClient<'a> {
             Controller::none(),
             None,
             |_, param| {
-                let mut param = param.unwrap();
+                let mut param = param.ok_or(Error::NoData)?;
                 let count = param.get_u16_le() as usize;
                 let mut controllers = vec![Controller::none(); count];
                 for i in 0..count {
@@ -268,7 +269,7 @@ impl<'a> ManagementClient<'a> {
             controller,
             None,
             |_, param| {
-                let mut param = param.unwrap();
+                let mut param = param.ok_or(Error::NoData)?;
                 Ok(ControllerConfigInfo {
                     manufacturer: param.get_u16_le(),
                     supported_options: param.get_flags_u32_le(),
@@ -304,7 +305,7 @@ impl<'a> ManagementClient<'a> {
             Controller::none(),
             None,
             |_, param| {
-                let mut param = param.unwrap();
+                let mut param = param.ok_or(Error::NoData)?;
                 let count = param.get_u16_le() as usize;
                 let mut index = Vec::with_capacity(count);
                 for _ in 0..count {
@@ -348,7 +349,7 @@ impl<'a> ManagementClient<'a> {
             controller,
             None,
             |_, param| {
-                let mut param = param.unwrap();
+                let mut param = param.ok_or(Error::NoData)?;
 
                 Ok(ControllerInfoExt {
                     address: param.get_address(),
@@ -374,7 +375,7 @@ impl<'a> ManagementClient<'a> {
     /// on the PHY configuration. It is remembered over power cycles.
     pub async fn get_phy_config(&mut self, controller: Controller) -> Result<PhyConfig> {
         self.exec_command(Command::GetPhyConfig, controller, None, |_, param| {
-            let mut param = param.unwrap();
+            let mut param = param.ok_or(Error::NoData)?;
             Ok(PhyConfig {
                 supported_phys: param.get_flags_u32_le(),
                 configurable_phys: param.get_flags_u32_le(),
@@ -393,10 +394,15 @@ impl<'a> ManagementClient<'a> {
         &mut self,
         controller: Controller,
     ) -> Result<HashMap<RuntimeConfigParameterType, Vec<u8>>> {
-        self.exec_command(Command::ReadDefaultRuntimeConfig, controller, None, |_, param| {
-            let mut param = param.unwrap();
-            Ok(param.get_tlv_map())
-        })
+        self.exec_command(
+            Command::ReadDefaultRuntimeConfig,
+            controller,
+            None,
+            |_, param| {
+                let mut param = param.ok_or(Error::NoData)?;
+                Ok(param.get_tlv_map())
+            },
+        )
         .await
     }
 
@@ -406,10 +412,15 @@ impl<'a> ManagementClient<'a> {
         &mut self,
         controller: Controller,
     ) -> Result<HashMap<SystemConfigParameterType, Vec<u8>>> {
-        self.exec_command(Command::ReadDefaultSystemConfig, controller, None, |_, param| {
-            let mut param = param.unwrap();
-            Ok(param.get_tlv_map())
-        })
+        self.exec_command(
+            Command::ReadDefaultSystemConfig,
+            controller,
+            None,
+            |_, param| {
+                let mut param = param.ok_or(Error::NoData)?;
+                Ok(param.get_tlv_map())
+            },
+        )
         .await
     }
 }

--- a/src/management/client/query.rs
+++ b/src/management/client/query.rs
@@ -7,9 +7,9 @@ use super::*;
 
 impl<'a> ManagementClient<'a> {
     /// This command returns the Management version and revision.
-    ///	Besides, being informational the information can be used to
-    ///	determine whether certain behavior has changed or bugs fixed
-    ///	when interacting with the kernel.
+    /// Besides, being informational the information can be used to
+    /// determine whether certain behavior has changed or bugs fixed
+    /// when interacting with the kernel.
     pub async fn get_mgmt_version(&mut self) -> Result<ManagementVersion> {
         self.exec_command(
             Command::ReadVersionInfo,
@@ -27,8 +27,8 @@ impl<'a> ManagementClient<'a> {
     }
 
     /// This command returns the list of currently known controllers.
-    ///	Controllers added or removed after calling this command can be
-    ///	monitored using the Index Added and Index Removed events.
+    /// Controllers added or removed after calling this command can be
+    /// monitored using the Index Added and Index Removed events.
     pub async fn get_controller_list(&mut self) -> Result<Vec<Controller>> {
         self.exec_command(
             Command::ReadControllerIndexList,
@@ -49,26 +49,26 @@ impl<'a> ManagementClient<'a> {
     }
 
     /// This command is used to retrieve the current state and basic
-    ///	information of a controller. It is typically used right after
-    ///	getting the response to the Read Controller Index List command
-    ///	or an Index Added event.
+    /// information of a controller. It is typically used right after
+    /// getting the response to the Read Controller Index List command
+    /// or an Index Added event.
     ///
-    ///	The `address` parameter describes the controllers public address
-    ///	and it can be expected that it is set. However in case of single
-    ///	mode Low Energy only controllers it can be `00:00:00:00:00:00`. To
-    ///	power on the controller in this case, it is required to configure
-    ///	a static address using Set Static `address` command first.
+    /// The `address` parameter describes the controllers public address
+    /// and it can be expected that it is set. However in case of single
+    /// mode Low Energy only controllers it can be `00:00:00:00:00:00`. To
+    /// power on the controller in this case, it is required to configure
+    /// a static address using Set Static `address` command first.
     ///
-    ///	If the public address is set, then it will be used as identity
-    ///	address for the controller. If no public address is available,
-    ///	then the configured static address will be used as identity
-    ///	address.
+    /// If the public address is set, then it will be used as identity
+    /// address for the controller. If no public address is available,
+    /// then the configured static address will be used as identity
+    /// address.
     ///
-    ///	In the case of a dual-mode controller with public address that
-    ///	is configured as Low Energy only device (BR/EDR switched off),
-    ///	the static address is used when set and public address otherwise.
+    /// In the case of a dual-mode controller with public address that
+    /// is configured as Low Energy only device (BR/EDR switched off),
+    /// the static address is used when set and public address otherwise.
     ///
-    ///	If no short name is set the Short_Name parameter will be all zeroes.
+    /// If no short name is set the Short_Name parameter will be all zeroes.
     pub async fn get_controller_info(&mut self, controller: Controller) -> Result<ControllerInfo> {
         self.exec_command(Command::ReadControllerInfo, controller, None, |_, param| {
             let mut param = param.unwrap();
@@ -87,14 +87,14 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to retrieve a list of currently connected
-    ///	devices.
+    /// This command is used to retrieve a list of currently connected
+    /// devices.
     ///
-    ///	For devices using resolvable random addresses with a known
-    ///	identity resolving key, the `address` and `address_type` will
-    ///	contain the identity information.
+    /// For devices using resolvable random addresses with a known
+    /// identity resolving key, the `address` and `address_type` will
+    /// contain the identity information.
     ///
-    ///	This command can only be used when the controller is powered.
+    /// This command can only be used when the controller is powered.
     pub async fn get_connections(
         &mut self,
         controller: Controller,
@@ -199,18 +199,18 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command returns the list of currently unconfigured controllers.
-    ///	Unconfigured controllers added after calling this command can be
-    ///	monitored using the Unconfigured Index Added event.
+    /// This command returns the list of currently unconfigured controllers.
+    /// Unconfigured controllers added after calling this command can be
+    /// monitored using the Unconfigured Index Added event.
     ///
-    ///	An unconfigured controller can either move to a configured state
-    ///	by indicating Unconfigured Index Removed event followed by an
-    ///	Index Added event; or it can be removed from the system which
-    ///	would be indicated by the Unconfigured Index Removed event.
+    /// An unconfigured controller can either move to a configured state
+    /// by indicating Unconfigured Index Removed event followed by an
+    /// Index Added event; or it can be removed from the system which
+    /// would be indicated by the Unconfigured Index Removed event.
     ///
-    ///	Only controllers that require configuration will be listed with
-    ///	this command. A controller that is fully configured will not
-    ///	be listed even if it supports configuration changes.
+    /// Only controllers that require configuration will be listed with
+    /// this command. A controller that is fully configured will not
+    /// be listed even if it supports configuration changes.
     pub async fn get_unconfigured_controller_list(&mut self) -> Result<Vec<Controller>> {
         self.exec_command(
             Command::ReadUnconfiguredControllerIndexList,
@@ -230,35 +230,35 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to retrieve the supported configuration
-    ///	options of a controller and the missing configuration options.
+    /// This command is used to retrieve the supported configuration
+    /// options of a controller and the missing configuration options.
     ///
-    ///	The missing options are required to be configured before the
-    ///	controller is considered fully configured and ready for standard
-    ///	operation. The command is typically used right after getting the
-    ///	response to Read Unconfigured Controller Index List command or
-    ///	Unconfigured Index Added event.
+    /// The missing options are required to be configured before the
+    /// controller is considered fully configured and ready for standard
+    /// operation. The command is typically used right after getting the
+    /// response to Read Unconfigured Controller Index List command or
+    /// Unconfigured Index Added event.
     ///
-    ///	Supported_Options and Missing_Options is a bitmask with currently
-    ///	the following available bits:
+    /// Supported_Options and Missing_Options is a bitmask with currently
+    /// the following available bits:
     ///
-    ///	0	External configuration
-    ///	1	Bluetooth public address configuration
+    /// 0 External configuration
+    /// 1 Bluetooth public address configuration
     ///
-    ///	It is valid to call this command on controllers that do not
-    ///	require any configuration. It is possible that a fully configured
-    ///	controller offers additional support for configuration.
+    /// It is valid to call this command on controllers that do not
+    /// require any configuration. It is possible that a fully configured
+    /// controller offers additional support for configuration.
     ///
-    ///	For example a controller may contain a valid Bluetooth public
-    ///	device address, but also allows to configure it from the host
-    ///	stack. In this case the general support for configurations will
-    ///	be indicated by the Controller Configuration settings. For
-    ///	controllers where no configuration options are available that
-    ///	setting option will not be present.
+    /// For example a controller may contain a valid Bluetooth public
+    /// device address, but also allows to configure it from the host
+    /// stack. In this case the general support for configurations will
+    /// be indicated by the Controller Configuration settings. For
+    /// controllers where no configuration options are available that
+    /// setting option will not be present.
     ///
-    ///	When all configurations have been completed and as a result the
-    ///	Missing_Options mask would become empty, then the now ready
-    ///	controller will be announced via Index Added event.
+    /// When all configurations have been completed and as a result the
+    /// Missing_Options mask would become empty, then the now ready
+    /// controller will be announced via Index Added event.
     pub async fn get_controller_config_info(
         &mut self,
         controller: Controller,
@@ -280,22 +280,22 @@ impl<'a> ManagementClient<'a> {
     }
 
     /// This command returns the list of currently known controllers. It
-    ///	includes configured, unconfigured and alternate controllers.
+    /// includes configured, unconfigured and alternate controllers.
     ///
-    ///	Controllers added or removed after calling this command can be
-    ///	be monitored using the Extended Index Added and Extended Index
-    ///	Removed events.
+    /// Controllers added or removed after calling this command can be
+    /// be monitored using the Extended Index Added and Extended Index
+    /// Removed events.
     ///
-    ///	The existing Index Added, Index Removed, Unconfigured Index Added
-    ///	and Unconfigured Index Removed are no longer sent after this command
-    ///	has been used at least once.
+    /// The existing Index Added, Index Removed, Unconfigured Index Added
+    /// and Unconfigured Index Removed are no longer sent after this command
+    /// has been used at least once.
     ///
-    ///	Instead of calling Read Controller Index List and Read Unconfigured
-    ///	Controller Index List, this command combines all the information
-    ///	and can be used to retrieve the controller list.
+    /// Instead of calling Read Controller Index List and Read Unconfigured
+    /// Controller Index List, this command combines all the information
+    /// and can be used to retrieve the controller list.
     ///
     /// Controllers marked as RAW only operation are currently not listed
-    ///	by this command.
+    /// by this command.
     pub async fn get_ext_controller_list(
         &mut self,
     ) -> Result<Vec<(Controller, ControllerType, ControllerBus)>> {
@@ -321,24 +321,24 @@ impl<'a> ManagementClient<'a> {
     }
 
     /// This command is used to retrieve the current state and basic
-    ///	information of a controller. It is typically used right after
-    ///	getting the response to the Read Controller Index List command
-    ///	or an Index Added event (or its extended counterparts).
+    /// information of a controller. It is typically used right after
+    /// getting the response to the Read Controller Index List command
+    /// or an Index Added event (or its extended counterparts).
     ///
-    ///	The Address parameter describes the controllers public address
-    ///	and it can be expected that it is set. However in case of single
-    ///	mode Low Energy only controllers it can be 00:00:00:00:00:00. To
-    ///	power on the controller in this case, it is required to configure
-    ///	a static address using Set Static Address command first.
+    /// The Address parameter describes the controllers public address
+    /// and it can be expected that it is set. However in case of single
+    /// mode Low Energy only controllers it can be 00:00:00:00:00:00. To
+    /// power on the controller in this case, it is required to configure
+    /// a static address using Set Static Address command first.
     ///
-    ///	If the public address is set, then it will be used as identity
-    ///	address for the controller. If no public address is available,
-    ///	then the configured static address will be used as identity
-    ///	address.
+    /// If the public address is set, then it will be used as identity
+    /// address for the controller. If no public address is available,
+    /// then the configured static address will be used as identity
+    /// address.
     ///
-    ///	In the case of a dual-mode controller with public address that
-    ///	is configured as Low Energy only device (BR/EDR switched off),
-    ///	the static address is used when set and public address otherwise.
+    /// In the case of a dual-mode controller with public address that
+    /// is configured as Low Energy only device (BR/EDR switched off),
+    /// the static address is used when set and public address otherwise.
     pub async fn get_ext_controller_info(
         &mut self,
         controller: Controller,
@@ -367,11 +367,11 @@ impl<'a> ManagementClient<'a> {
     }
 
     /// If BR/EDR is supported, then BR 1M 1-Slot is supported by
-    ///	default and can also not be deselected. If LE is supported,
-    ///	then LE 1M TX and LE 1M RX are supported by default.
+    /// default and can also not be deselected. If LE is supported,
+    /// then LE 1M TX and LE 1M RX are supported by default.
     ///
-    ///	Disabling BR/EDR completely or respectively LE has no impact
-    ///	on the PHY configuration. It is remembered over power cycles.
+    /// Disabling BR/EDR completely or respectively LE has no impact
+    /// on the PHY configuration. It is remembered over power cycles.
     pub async fn get_phy_config(&mut self, controller: Controller) -> Result<PhyConfig> {
         self.exec_command(Command::GetPhyConfig, controller, None, |_, param| {
             let mut param = param.unwrap();

--- a/src/management/client/settings.rs
+++ b/src/management/client/settings.rs
@@ -11,7 +11,7 @@ use crate::util::BufExtBlueZ;
 
 // use some consts for common callback patterns
 fn settings_callback(_: Controller, param: Option<Bytes>) -> Result<ControllerSettings> {
-    Ok(param.unwrap().get_flags_u32_le())
+    Ok(param.ok_or(Error::NoData)?.get_flags_u32_le())
 }
 
 impl<'a> ManagementClient<'a> {
@@ -67,7 +67,7 @@ impl<'a> ManagementClient<'a> {
             controller,
             Some(param.freeze()),
             |_, param| {
-                let mut param = param.unwrap();
+                let mut param = param.ok_or(Error::NoData)?;
 
                 Ok((param.split_to(249).get_c_string(), param.get_c_string()))
             },

--- a/src/management/client/settings.rs
+++ b/src/management/client/settings.rs
@@ -16,19 +16,19 @@ fn settings_callback(_: Controller, param: Option<Bytes>) -> Result<ControllerSe
 
 impl<'a> ManagementClient<'a> {
     /// This command is used to set the local name of a controller. The
-    ///	command parameters also include a short name which will be used
-    ///	in case the full name doesn't fit within EIR/AD data.
+    /// command parameters also include a short name which will be used
+    /// in case the full name doesn't fit within EIR/AD data.
     ///
     /// Name can be at most 248 bytes. Short name can be at most 10 bytes.
     /// This function returns a pair of OsStrings in the order (name, short_name).
     ///
-    ///	This command can be used when the controller is not powered and
-    ///	all settings will be programmed once powered.
+    /// This command can be used when the controller is not powered and
+    /// all settings will be programmed once powered.
     ///
-    ///	The values of name and short name will be remembered when
-    ///	switching the controller off and back on again. So the name
-    ///	and short name only have to be set once when a new controller
-    ///	is found and will stay until removed.
+    /// The values of name and short name will be remembered when
+    /// switching the controller off and back on again. So the name
+    /// and short name only have to be set once when a new controller
+    /// is found and will stay until removed.
     pub async fn set_local_name(
         &mut self,
         controller: Controller,
@@ -77,18 +77,18 @@ impl<'a> ManagementClient<'a> {
 
     /// This command is used to power on or off a controller.
     ///
-    ///	If discoverable setting is activated with a timeout, then
-    ///	switching the controller off will expire this timeout and
-    ///	disable discoverable.
+    /// If discoverable setting is activated with a timeout, then
+    /// switching the controller off will expire this timeout and
+    /// disable discoverable.
     ///
-    ///	Settings programmed via Set Advertising and Add/Remove
-    ///	Advertising while the controller was powered off will be activated
-    ///	when powering the controller on.
+    /// Settings programmed via Set Advertising and Add/Remove
+    /// Advertising while the controller was powered off will be activated
+    /// when powering the controller on.
     ///
-    ///	Switching the controller off will permanently cancel and remove
-    ///	all advertising instances with a timeout set, i.e. time limited
-    ///	advertising instances are not being remembered across power cycles.
-    ///	Advertising Removed events will be issued accordingly.
+    /// Switching the controller off will permanently cancel and remove
+    /// all advertising instances with a timeout set, i.e. time limited
+    /// advertising instances are not being remembered across power cycles.
+    /// Advertising Removed events will be issued accordingly.
     pub async fn set_powered(
         &mut self,
         controller: Controller,
@@ -107,23 +107,23 @@ impl<'a> ManagementClient<'a> {
     }
 
     /// This command is used to set the discoverable property of a
-    ///	controller.
+    /// controller.
     ///
-    ///	Timeout is the time in seconds and is only meaningful when
-    ///	Discoverable is set to General or Limited. Providing a timeout
-    ///	with None returns Invalid Parameters. For Limited, the timeout
-    ///	is required.
+    /// Timeout is the time in seconds and is only meaningful when
+    /// Discoverable is set to General or Limited. Providing a timeout
+    /// with None returns Invalid Parameters. For Limited, the timeout
+    /// is required.
     ///
-    ///	This command is only available for BR/EDR capable controllers
-    ///	(e.g. not for single-mode LE ones). It will return Not Supported
-    ///	otherwise.
+    /// This command is only available for BR/EDR capable controllers
+    /// (e.g. not for single-mode LE ones). It will return Not Supported
+    /// otherwise.
     ///
-    ///	This command can be used when the controller is not powered and
-    ///	all settings will be programmed once powered, however using a timeout
-    /// when the controller is not powered will	return Not Powered error.
+    /// This command can be used when the controller is not powered and
+    /// all settings will be programmed once powered, however using a timeout
+    /// when the controller is not powered will return Not Powered error.
     ///
-    ///	When switching discoverable on and the connectable setting is
-    ///	off it will return Rejected error.
+    /// When switching discoverable on and the connectable setting is
+    /// off it will return Rejected error.
     pub async fn set_discoverable(
         &mut self,
         controller: Controller,
@@ -146,30 +146,30 @@ impl<'a> ManagementClient<'a> {
     }
 
     /// This command is used to set the connectable property of a
-    ///	controller.
+    /// controller.
     ///
-    ///	This command is available for BR/EDR, LE-only and also dual
-    ///	mode controllers. For BR/EDR is changes the page scan setting
-    ///	and for LE controllers it changes the advertising type. For
-    ///	dual mode controllers it affects both settings.
+    /// This command is available for BR/EDR, LE-only and also dual
+    /// mode controllers. For BR/EDR is changes the page scan setting
+    /// and for LE controllers it changes the advertising type. For
+    /// dual mode controllers it affects both settings.
     ///
-    ///	For LE capable controllers the connectable setting takes effect
-    ///	when advertising is enabled (peripheral) or when directed
-    ///	advertising events are received (central).
+    /// For LE capable controllers the connectable setting takes effect
+    /// when advertising is enabled (peripheral) or when directed
+    /// advertising events are received (central).
     ///
-    ///	This command can be used when the controller is not powered and
-    ///	all settings will be programmed once powered.
+    /// This command can be used when the controller is not powered and
+    /// all settings will be programmed once powered.
     ///
-    ///	When switching connectable off, it will also switch off the
-    ///	discoverable setting. Switching connectable back on will not
-    ///	restore a previous discoverable. It will stay off and needs
-    ///	to be manually switched back on.
+    /// When switching connectable off, it will also switch off the
+    /// discoverable setting. Switching connectable back on will not
+    /// restore a previous discoverable. It will stay off and needs
+    /// to be manually switched back on.
     ///
-    ///	When switching connectable off, it will expire a discoverable
-    ///	setting with a timeout.
+    /// When switching connectable off, it will expire a discoverable
+    /// setting with a timeout.
     ///
-    ///	This setting does not affect known devices from Add Device
-    ///	command. These devices are always allowed to connect.
+    /// This setting does not affect known devices from Add Device
+    /// command. These devices are always allowed to connect.
     pub async fn set_connectable(
         &mut self,
         controller: Controller,
@@ -188,18 +188,18 @@ impl<'a> ManagementClient<'a> {
     }
 
     /// This command is used to set the controller into a connectable
-    ///	state where the page scan parameters have been set in a way to
-    ///	favor faster connect times with the expense of higher power
-    ///	consumption.
+    /// state where the page scan parameters have been set in a way to
+    /// favor faster connect times with the expense of higher power
+    /// consumption.
     ///
-    ///	This command is only available for BR/EDR capable controllers
-    ///	(e.g. not for single-mode LE ones). It will return Not Supported
-    ///	otherwise.
+    /// This command is only available for BR/EDR capable controllers
+    /// (e.g. not for single-mode LE ones). It will return Not Supported
+    /// otherwise.
     ///
-    ///	This command can be used when the controller is not powered and
-    ///	all settings will be programmed once powered.
+    /// This command can be used when the controller is not powered and
+    /// all settings will be programmed once powered.
     ///
-    ///	The setting will be remembered during power down/up toggles.
+    /// The setting will be remembered during power down/up toggles.
     pub async fn set_fast_connectable(
         &mut self,
         controller: Controller,
@@ -218,15 +218,15 @@ impl<'a> ManagementClient<'a> {
     }
 
     /// This command is used to set the bondable (pairable) property of an
-    ///	controller.
+    /// controller.
     ///
-    ///	This command can be used when the controller is not powered and
-    ///	all settings will be programmed once powered.
+    /// This command can be used when the controller is not powered and
+    /// all settings will be programmed once powered.
     ///
-    ///	Turning bondable on will not automatically switch the controller
-    ///	into connectable mode. That needs to be done separately.
+    /// Turning bondable on will not automatically switch the controller
+    /// into connectable mode. That needs to be done separately.
     ///
-    ///	The setting will be remembered during power down/up toggles.
+    /// The setting will be remembered during power down/up toggles.
     pub async fn set_bondable(
         &mut self,
         controller: Controller,
@@ -244,15 +244,15 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to either enable or disable link level
-    ///	security for an controller (also known as Security Mode 3).
+    /// This command is used to either enable or disable link level
+    /// security for an controller (also known as Security Mode 3).
     ///
-    ///	This command is only available for BR/EDR capable controllers
-    ///	(e.g. not for single-mode LE ones). It will return Not Supported
-    ///	otherwise.
+    /// This command is only available for BR/EDR capable controllers
+    /// (e.g. not for single-mode LE ones). It will return Not Supported
+    /// otherwise.
     ///
-    ///	This command can be used when the controller is not powered and
-    ///	all settings will be programmed once powered.
+    /// This command can be used when the controller is not powered and
+    /// all settings will be programmed once powered.
     pub async fn set_link_security(
         &mut self,
         controller: Controller,
@@ -270,18 +270,18 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to enable/disable Secure Simple Pairing
-    ///	support for a controller.
+    /// This command is used to enable/disable Secure Simple Pairing
+    /// support for a controller.
     ///
-    ///	This command is only available for BR/EDR capable controllers
-    ///	supporting the core specification version 2.1 or greater
-    ///	(e.g. not for single-mode LE controllers or pre-2.1 ones).
+    /// This command is only available for BR/EDR capable controllers
+    /// supporting the core specification version 2.1 or greater
+    /// (e.g. not for single-mode LE controllers or pre-2.1 ones).
     ///
-    ///	This command can be used when the controller is not powered and
-    ///	all settings will be programmed once powered.
+    /// This command can be used when the controller is not powered and
+    /// all settings will be programmed once powered.
     ///
-    ///	In case the controller does not support Secure Simple Pairing,
-    ///	the command will fail regardless with Not Supported error.
+    /// In case the controller does not support Secure Simple Pairing,
+    /// the command will fail regardless with Not Supported error.
     pub async fn set_ssp(
         &mut self,
         controller: Controller,
@@ -299,23 +299,23 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to enable/disable Bluetooth High Speed
-    ///	support for a controller.
+    /// This command is used to enable/disable Bluetooth High Speed
+    /// support for a controller.
     ///
-    ///	This command is only available for BR/EDR capable controllers
-    ///	(e.g. not for single-mode LE ones).
+    /// This command is only available for BR/EDR capable controllers
+    /// (e.g. not for single-mode LE ones).
     ///
-    ///	This command can be used when the controller is not powered and
-    ///	all settings will be programmed once powered.
+    /// This command can be used when the controller is not powered and
+    /// all settings will be programmed once powered.
     ///
-    ///	To enable High Speed support, it is required that Secure Simple
-    ///	Pairing support is enabled first. High Speed support is not
-    ///	possible for connections without Secure Simple Pairing.
+    /// To enable High Speed support, it is required that Secure Simple
+    /// Pairing support is enabled first. High Speed support is not
+    /// possible for connections without Secure Simple Pairing.
     ///
-    ///	When switching Secure Simple Pairing off, the support for High
-    ///	Speed will be switched off as well. Switching Secure Simple
-    ///	Pairing back on, will not re-enable High Speed support. That
-    ///	needs to be done manually.
+    /// When switching Secure Simple Pairing off, the support for High
+    /// Speed will be switched off as well. Switching Secure Simple
+    /// Pairing back on, will not re-enable High Speed support. That
+    /// needs to be done manually.
     pub async fn set_high_speed(
         &mut self,
         controller: Controller,
@@ -334,20 +334,20 @@ impl<'a> ManagementClient<'a> {
     }
 
     /// This command is used to enable/disable Low Energy support for a
-    ///	controller.
+    /// controller.
     ///
-    ///	This command is only available for LE capable controllers and
-    ///	will yield in a Not Supported error otherwise.
+    /// This command is only available for LE capable controllers and
+    /// will yield in a Not Supported error otherwise.
     ///
-    ///	This command can be used when the controller is not powered and
-    ///	all settings will be programmed once powered.
+    /// This command can be used when the controller is not powered and
+    /// all settings will be programmed once powered.
     ///
-    ///	In case the kernel subsystem does not support Low Energy or the
-    ///	controller does not either, the command will fail regardless.
+    /// In case the kernel subsystem does not support Low Energy or the
+    /// controller does not either, the command will fail regardless.
     ///
-    ///	Disabling LE support will permanently disable and remove all
-    ///	advertising instances configured with the Add Advertising
-    ///	command. Advertising Removed events will be issued accordingly.
+    /// Disabling LE support will permanently disable and remove all
+    /// advertising instances configured with the Add Advertising
+    /// command. Advertising Removed events will be issued accordingly.
     pub async fn set_le(&mut self, controller: Controller, le: bool) -> Result<ControllerSettings> {
         let mut param = BytesMut::with_capacity(1);
         param.put_u8(le as u8);
@@ -362,39 +362,39 @@ impl<'a> ManagementClient<'a> {
     }
 
     /// This command is used to enable LE advertising on a controller
-    ///	that supports it.
+    /// that supports it.
     ///
-    ///	The value `Disabled` disables advertising, the value `WithConnectable` enables
-    ///	advertising with considering of connectable setting and the
-    ///	value `Enabled` enables advertising in connectable mode.
+    /// The value `Disabled` disables advertising, the value `WithConnectable` enables
+    /// advertising with considering of connectable setting and the
+    /// value `Enabled` enables advertising in connectable mode.
     ///
-    ///	Using value `WithConnectable` means that when connectable setting is disabled,
-    ///	the advertising happens with undirected non-connectable advertising
-    ///	packets and a non-resolvable random address is used. If connectable
-    ///	setting is enabled, then undirected connectable advertising packets
-    ///	and the identity address or resolvable private address are used.
+    /// Using value `WithConnectable` means that when connectable setting is disabled,
+    /// the advertising happens with undirected non-connectable advertising
+    /// packets and a non-resolvable random address is used. If connectable
+    /// setting is enabled, then undirected connectable advertising packets
+    /// and the identity address or resolvable private address are used.
     ///
-    ///	LE Devices configured via Add Device command with Action `0x01`
-    ///	have no effect when using Advertising value `0x01` since only the
-    ///	connectable setting is taken into account.
+    /// LE Devices configured via Add Device command with Action `0x01`
+    /// have no effect when using Advertising value `0x01` since only the
+    /// connectable setting is taken into account.
     ///
-    ///	To utilize undirected connectable advertising without changing the
-    ///	connectable setting, the value `Enabled` can be utilized. It makes the
-    ///	device connectable via LE without the requirement for being
-    ///	connectable on BR/EDR (and/or LE).
+    /// To utilize undirected connectable advertising without changing the
+    /// connectable setting, the value `Enabled` can be utilized. It makes the
+    /// device connectable via LE without the requirement for being
+    /// connectable on BR/EDR (and/or LE).
     ///
-    ///	The value `Enabled` should be the preferred mode of operation when
-    ///	implementing peripheral mode.
+    /// The value `Enabled` should be the preferred mode of operation when
+    /// implementing peripheral mode.
     ///
-    ///	Using this command will temporarily deactivate any configuration
-    ///	made by the Add Advertising command. This command takes precedence.
-    ///	Once a Set Advertising command with value `Disabled` is issued any
-    ///	previously made configurations via Add/Remove Advertising, including
-    ///	such changes made while Set Advertising was active, will be re-
-    ///	enabled.
+    /// Using this command will temporarily deactivate any configuration
+    /// made by the Add Advertising command. This command takes precedence.
+    /// Once a Set Advertising command with value `Disabled` is issued any
+    /// previously made configurations via Add/Remove Advertising, including
+    /// such changes made while Set Advertising was active, will be re-
+    /// enabled.
     ///
-    ///	A pre-requisite is that LE is already enabled, otherwise this
-    ///	command will return a "rejected" response.
+    /// A pre-requisite is that LE is already enabled, otherwise this
+    /// command will return a "rejected" response.
     pub async fn set_advertising(
         &mut self,
         controller: Controller,
@@ -413,14 +413,14 @@ impl<'a> ManagementClient<'a> {
     }
 
     /// This command is used to enable or disable BR/EDR support
-    ///	on a dual-mode controller.
+    /// on a dual-mode controller.
     ///
-    ///	A pre-requisite is that LE is already enabled, otherwise
-    ///	this command will return a "rejected" response. Enabling BR/EDR
-    ///	can be done both when powered on and powered off, however
-    ///	disabling it can only be done when powered off (otherwise the
-    ///	command will again return "rejected"). Disabling BR/EDR will
-    ///	automatically disable all other BR/EDR related settings.
+    /// A pre-requisite is that LE is already enabled, otherwise
+    /// this command will return a "rejected" response. Enabling BR/EDR
+    /// can be done both when powered on and powered off, however
+    /// disabling it can only be done when powered off (otherwise the
+    /// command will again return "rejected"). Disabling BR/EDR will
+    /// automatically disable all other BR/EDR related settings.
     pub async fn set_bredr(
         &mut self,
         controller: Controller,
@@ -438,14 +438,14 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to set the IO Capability used for pairing.
-    ///	The command accepts both SSP and SMP values.
+    /// This command is used to set the IO Capability used for pairing.
+    /// The command accepts both SSP and SMP values.
     ///
-    ///	Passing KeyboardDisplay will cause the kernel to
-    ///	convert it to DisplayYesNo)in the case of a BR/EDR
-    ///	connection (as KeyboardDisplay is specific to SMP).
+    /// Passing KeyboardDisplay will cause the kernel to
+    /// convert it to DisplayYesNo)in the case of a BR/EDR
+    /// connection (as KeyboardDisplay is specific to SMP).
     ///
-    ///	This command can be used when the controller is not powered.
+    /// This command can be used when the controller is not powered.
     pub async fn set_io_capability(
         &mut self,
         controller: Controller,
@@ -464,19 +464,19 @@ impl<'a> ManagementClient<'a> {
     }
 
     /// This command can be used when the controller is not powered and
-    ///	all settings will be programmed once powered.
+    /// all settings will be programmed once powered.
     ///
-    ///	The Source parameter selects the organization that assigned the
-    ///	Vendor parameter:
+    /// The Source parameter selects the organization that assigned the
+    /// Vendor parameter:
     ///
-    ///	 - `0x0000`	Disable Device ID
-    ///	 - `0x0001`	Bluetooth SIG
-    ///	 - `0x0002`	USB Implementer's Forum
+    ///  - `0x0000` Disable Device ID
+    ///  - `0x0001` Bluetooth SIG
+    ///  - `0x0002` USB Implementer's Forum
     ///
-    ///	The information is put into the EIR data. If the controller does
-    ///	not support EIR or if SSP is disabled, this command will still
-    ///	succeed. The information is stored for later use and will survive
-    ///	toggling SSP on and off.
+    /// The information is put into the EIR data. If the controller does
+    /// not support EIR or if SSP is disabled, this command will still
+    /// succeed. The information is stored for later use and will survive
+    /// toggling SSP on and off.
     pub async fn set_device_id(
         &mut self,
         controller: Controller,
@@ -501,8 +501,8 @@ impl<'a> ManagementClient<'a> {
     }
 
     /// This command allows for setting the Low Energy scan parameters
-    ///	used for connection establishment and passive scanning. It is
-    ///	only supported on controllers with LE support.
+    /// used for connection establishment and passive scanning. It is
+    /// only supported on controllers with LE support.
     pub async fn set_scan_parameters(
         &mut self,
         controller: Controller,
@@ -522,29 +522,29 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command allows for setting the static random address. It is
-    ///	only supported on controllers with LE support. The static random
-    ///	address is suppose to be valid for the lifetime of the
-    ///	controller or at least until the next power cycle. To ensure
-    ///	such behavior, setting of the address is limited to when the
-    ///	controller is powered off.
+    /// This command allows for setting the static random address. It is
+    /// only supported on controllers with LE support. The static random
+    /// address is suppose to be valid for the lifetime of the
+    /// controller or at least until the next power cycle. To ensure
+    /// such behavior, setting of the address is limited to when the
+    /// controller is powered off.
     ///
-    ///	The `Address::zero()` (`00:00:00:00:00:00`) can be used
-    ///	to disable the static address.
+    /// The `Address::zero()` (`00:00:00:00:00:00`) can be used
+    /// to disable the static address.
     ///
-    ///	When a controller has a public address (which is required for
-    ///	all dual-mode controllers), this address is not used. If a dual-mode
-    ///	controller is configured as Low Energy only devices (BR/EDR has
-    ///	been switched off), then the static address is used. Only when
-    ///	the controller information reports a zero address (`00:00:00:00:00:00`),
-    ///	it is required to configure a static address first.
+    /// When a controller has a public address (which is required for
+    /// all dual-mode controllers), this address is not used. If a dual-mode
+    /// controller is configured as Low Energy only devices (BR/EDR has
+    /// been switched off), then the static address is used. Only when
+    /// the controller information reports a zero address (`00:00:00:00:00:00`),
+    /// it is required to configure a static address first.
     ///
-    ///	If privacy mode is enabled and the controller is single mode
-    ///	LE only without a public address, the static random address is
-    ///	used as identity address.
+    /// If privacy mode is enabled and the controller is single mode
+    /// LE only without a public address, the static random address is
+    /// used as identity address.
     ///
-    ///	The Static Address flag from the current settings can also be used
-    ///	to determine if the configured static address is in use or not.
+    /// The Static Address flag from the current settings can also be used
+    /// to determine if the configured static address is in use or not.
     pub async fn set_static_address(
         &mut self,
         controller: Controller,
@@ -561,22 +561,22 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to enable/disable Secure Connections
-    ///	support for a controller.
+    /// This command is used to enable/disable Secure Connections
+    /// support for a controller.
     ///
-    ///	The value `Disabled` disables Secure Connections, the value `Enabled`
-    ///	enables Secure Connections and the value `Only` enables Secure
-    ///	Connections Only mode.
+    /// The value `Disabled` disables Secure Connections, the value `Enabled`
+    /// enables Secure Connections and the value `Only` enables Secure
+    /// Connections Only mode.
     ///
-    ///	This command is only available for LE capable controllers as
-    ///	well as controllers supporting the core specification version
-    ///	4.1 or greater.
+    /// This command is only available for LE capable controllers as
+    /// well as controllers supporting the core specification version
+    /// 4.1 or greater.
     ///
-    ///	This command can be used when the controller is not powered and
-    ///	all settings will be programmed once powered.
+    /// This command can be used when the controller is not powered and
+    /// all settings will be programmed once powered.
     ///
-    ///	In case the controller does not support Secure Connections
-    ///	the command will fail regardless with Not Supported error.
+    /// In case the controller does not support Secure Connections
+    /// the command will fail regardless with Not Supported error.
     pub async fn set_secure_connections_mode(
         &mut self,
         controller: Controller,
@@ -595,22 +595,22 @@ impl<'a> ManagementClient<'a> {
     }
 
     /// This command is used to tell the kernel whether to accept the
-    ///	usage of debug keys or not.
+    /// usage of debug keys or not.
     ///
-    ///	With a value of `Discard` any generated debug key will be discarded
-    ///	as soon as the connection terminates.
+    /// With a value of `Discard` any generated debug key will be discarded
+    /// as soon as the connection terminates.
     ///
-    ///	With a value of `Persist` generated debug keys will be kept and can
-    ///	be used for future connections. However debug keys are always
-    ///	marked as non persistent and should not be stored. This means
-    ///	a reboot or changing the value back to `0x00` will delete them.
+    /// With a value of `Persist` generated debug keys will be kept and can
+    /// be used for future connections. However debug keys are always
+    /// marked as non persistent and should not be stored. This means
+    /// a reboot or changing the value back to `0x00` will delete them.
     ///
-    ///	With a value of `PersistAndGenerate` generated debug keys will be kept and can
-    ///	be used for future connections. This has the same affect as
-    ///	with value `Persist`. However in addition this value will also
-    ///	enter the controller mode to generate debug keys for each
-    ///	new pairing. Changing the value back to `Persist` or `Discard` will
-    ///	disable the controller mode for generating debug keys.
+    /// With a value of `PersistAndGenerate` generated debug keys will be kept and can
+    /// be used for future connections. This has the same affect as
+    /// with value `Persist`. However in addition this value will also
+    /// enter the controller mode to generate debug keys for each
+    /// new pairing. Changing the value back to `Persist` or `Discard` will
+    /// disable the controller mode for generating debug keys.
     pub async fn set_debug_mode(
         &mut self,
         controller: Controller,
@@ -628,40 +628,40 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to enable Low Energy Privacy feature using
-    ///	resolvable private addresses.
+    /// This command is used to enable Low Energy Privacy feature using
+    /// resolvable private addresses.
     ///
-    ///	The value `Disabled` disables privacy mode, the values `Strict` and `Limited`
-    ///	enable privacy mode.
+    /// The value `Disabled` disables privacy mode, the values `Strict` and `Limited`
+    /// enable privacy mode.
     ///
-    ///	With value `Strict` the kernel will always use the privacy mode. This
-    ///	means resolvable private address is used when the controller is
-    ///	discoverable and also when pairing is initiated.
+    /// With value `Strict` the kernel will always use the privacy mode. This
+    /// means resolvable private address is used when the controller is
+    /// discoverable and also when pairing is initiated.
     ///
-    ///	With value `Limited` the kernel will use a limited privacy mode with a
-    ///	resolvable private address except when the controller is bondable
-    ///	and discoverable, in which case the identity address is used.
+    /// With value `Limited` the kernel will use a limited privacy mode with a
+    /// resolvable private address except when the controller is bondable
+    /// and discoverable, in which case the identity address is used.
     ///
-    ///	Exposing the identity address when bondable and discoverable or
-    ///	during initiated pairing can be a privacy issue. For dual-mode
-    ///	controllers this can be neglected since its public address will
-    ///	be exposed over BR/EDR anyway. The benefit of exposing the
-    ///	identity address for pairing purposes is that it makes matching
-    ///	up devices with dual-mode topology during device discovery now
-    ///	possible.
+    /// Exposing the identity address when bondable and discoverable or
+    /// during initiated pairing can be a privacy issue. For dual-mode
+    /// controllers this can be neglected since its public address will
+    /// be exposed over BR/EDR anyway. The benefit of exposing the
+    /// identity address for pairing purposes is that it makes matching
+    /// up devices with dual-mode topology during device discovery now
+    /// possible.
     ///
-    ///	If the privacy value `Limited` is used, then also the GATT database
-    ///	should expose the Privacy Characteristic so that remote devices
-    ///	can determine if the privacy feature is in use or not.
+    /// If the privacy value `Limited` is used, then also the GATT database
+    /// should expose the Privacy Characteristic so that remote devices
+    /// can determine if the privacy feature is in use or not.
     ///
-    ///	When the controller has a public address (mandatory for dual-mode
-    ///	controllers) it is used as identity address. In case the controller
-    ///	is single mode LE only without a public address, it is required
-    ///	to configure a static random address first. The privacy mode can
-    ///	only be enabled when an identity address is available.
+    /// When the controller has a public address (mandatory for dual-mode
+    /// controllers) it is used as identity address. In case the controller
+    /// is single mode LE only without a public address, it is required
+    /// to configure a static random address first. The privacy mode can
+    /// only be enabled when an identity address is available.
     ///
-    ///	The identity_resolving_key is the local key assigned for the local
-    ///	resolvable private address.
+    /// The identity_resolving_key is the local key assigned for the local
+    /// resolvable private address.
     pub async fn set_privacy_mode(
         &mut self,
         controller: Controller,
@@ -681,23 +681,23 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command allows to change external configuration option to
-    ///	indicate that a controller is now configured or unconfigured.
+    /// This command allows to change external configuration option to
+    /// indicate that a controller is now configured or unconfigured.
     ///
-    ///	The value false sets unconfigured state and the value true sets
-    ///	configured state of the controller.
+    /// The value false sets unconfigured state and the value true sets
+    /// configured state of the controller.
     ///
-    ///	It is not mandatory that this configuration option is provided
-    ///	by a controller. If it is provided, the configuration has to
-    ///	happen externally using user channel operation or via vendor
-    ///	specific methods.
+    /// It is not mandatory that this configuration option is provided
+    /// by a controller. If it is provided, the configuration has to
+    /// happen externally using user channel operation or via vendor
+    /// specific methods.
     ///
-    ///	Setting this option and when Missing_Options returns zero, this
-    ///	means that the controller will switch to configured state and it
-    ///	can be expected that it will be announced via Index Added event.
+    /// Setting this option and when Missing_Options returns zero, this
+    /// means that the controller will switch to configured state and it
+    /// can be expected that it will be announced via Index Added event.
     ///
-    ///	Wrongly configured controllers might still cause an error when
-    ///	trying to power them via Set Powered command.
+    /// Wrongly configured controllers might still cause an error when
+    /// trying to power them via Set Powered command.
     pub async fn set_external_config(
         &mut self,
         controller: Controller,
@@ -714,32 +714,32 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command allows configuration of public address. Since a vendor
-    ///	specific procedure is required, this command might not be supported
-    ///	by all controllers. Actually most likely only a handful embedded
-    ///	controllers will offer support for this command.
+    /// This command allows configuration of public address. Since a vendor
+    /// specific procedure is required, this command might not be supported
+    /// by all controllers. Actually most likely only a handful embedded
+    /// controllers will offer support for this command.
     ///
-    ///	When the support for Bluetooth public address configuration is
-    ///	indicated in the supported options mask, then this command
-    ///	can be used to configure the public address.
+    /// When the support for Bluetooth public address configuration is
+    /// indicated in the supported options mask, then this command
+    /// can be used to configure the public address.
     ///
-    ///	It is only possible to configure the public address when the
-    ///	controller is powered off.
+    /// It is only possible to configure the public address when the
+    /// controller is powered off.
     ///
-    ///	For an unconfigured controller and when this function returns
-    ///	an empty mask, this means that a Index Added event for the now
-    ///	fully configured controller can be expected.
+    /// For an unconfigured controller and when this function returns
+    /// an empty mask, this means that a Index Added event for the now
+    /// fully configured controller can be expected.
     ///
-    ///	For a fully configured controller, the current controller index
-    ///	will become invalid and an Unconfigured Index Removed event will
-    ///	be sent. Once the address has been successfully changed an Index
-    ///	Added event will be sent. There is no guarantee that the controller
-    ///	index stays the same.
+    /// For a fully configured controller, the current controller index
+    /// will become invalid and an Unconfigured Index Removed event will
+    /// be sent. Once the address has been successfully changed an Index
+    /// Added event will be sent. There is no guarantee that the controller
+    /// index stays the same.
     ///
-    ///	All previous configured parameters and settings are lost when
-    ///	this command succeeds. The controller has to be treated as new
-    ///	one. Use this command for a fully configured controller only when
-    ///	you really know what you are doing.
+    /// All previous configured parameters and settings are lost when
+    /// this command succeeds. The controller has to be treated as new
+    /// one. Use this command for a fully configured controller only when
+    /// you really know what you are doing.
     pub async fn set_public_address(
         &mut self,
         controller: Controller,
@@ -756,15 +756,15 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	This command is used to set the appearance value of a controller.
+    /// This command is used to set the appearance value of a controller.
     ///
-    ///	This command can be used when the controller is not
-    ///	powered and all settings will be programmed once powered.
+    /// This command can be used when the controller is not
+    /// powered and all settings will be programmed once powered.
     ///
-    ///	The value of appearance will be remembered when switching
-    ///	the controller off and back on again. So the appearance only
-    ///	have to be set once when a new controller is found and will
-    ///	stay until removed.
+    /// The value of appearance will be remembered when switching
+    /// the controller off and back on again. So the appearance only
+    /// have to be set once when a new controller is found and will
+    /// stay until removed.
     // todo: implement appearance as enum instead of u16
     pub async fn set_appearance(&mut self, controller: Controller, appearance: u16) -> Result<()> {
         let mut param = BytesMut::with_capacity(2);
@@ -779,7 +779,7 @@ impl<'a> ManagementClient<'a> {
         .await
     }
 
-    ///	on the PHY configuration. It is remembered over power cycles.
+    /// on the PHY configuration. It is remembered over power cycles.
     pub async fn set_phy_config(
         &mut self,
         controller: Controller,

--- a/src/management/interface/class.rs
+++ b/src/management/interface/class.rs
@@ -1,6 +1,6 @@
-use bitvec::{view::BitView, field::BitField, prelude as bv};
+use bitvec::{field::BitField, prelude as bv, view::BitView};
 use bytes::{Buf, Bytes};
-use enumflags2::{BitFlags, bitflags};
+use enumflags2::{bitflags, BitFlags};
 
 #[bitflags]
 #[repr(u32)]

--- a/src/management/interface/class.rs
+++ b/src/management/interface/class.rs
@@ -276,11 +276,11 @@ pub fn device_class_from_u32(class: u32) -> (DeviceClass, ServiceClasses) {
     (device_class, service_classes)
 }
 
-impl Into<u16> for DeviceClass {
-    fn into(self) -> u16 {
+impl From<DeviceClass> for u16 {
+    fn from(val: DeviceClass) -> Self {
         let mut bits = 0u16;
 
-        match self {
+        match val {
             DeviceClass::Computer(minor) => {
                 bits |= 0b00001 << 8;
                 match minor {

--- a/src/management/interface/class.rs
+++ b/src/management/interface/class.rs
@@ -165,10 +165,9 @@ pub fn device_class_from_u32(class: u32) -> (DeviceClass, ServiceClasses) {
     let service_classes = ServiceClasses::from_bits_truncate(class);
 
     let class_bits = class.view_bits::<bv::Lsb0>();
-    let device_class: DeviceClass;
 
     // major device class encoded in bits 8-12
-    device_class = match class_bits[8..13].load::<u8>() {
+    let device_class = match class_bits[8..13].load::<u8>() {
         // minor device class in bits 2-7
         0b00001 => DeviceClass::Computer(match class_bits[2..8].load::<u8>() {
             0b000000 => ComputerDeviceClass::Uncategorized,

--- a/src/management/interface/controller.rs
+++ b/src/management/interface/controller.rs
@@ -48,13 +48,13 @@ pub struct ControllerInfoExt {
     pub current_settings: ControllerSettings,
 
     /// Contains information about class of device,
-    ///	local name and other values. Not all of them might be present. For
-    ///	example a Low Energy only device does not contain class of device
-    ///	information.
+    /// local name and other values. Not all of them might be present. For
+    /// example a Low Energy only device does not contain class of device
+    /// information.
     ///
-    ///	When any of the values in the `eir_data` field changes, the event
-    ///	Extended Controller Information Changed will be used to inform
-    ///	clients about the updated information.
+    /// When any of the values in the `eir_data` field changes, the event
+    /// Extended Controller Information Changed will be used to inform
+    /// clients about the updated information.
     pub eir_data: Bytes,
 }
 

--- a/src/management/interface/controller.rs
+++ b/src/management/interface/controller.rs
@@ -2,7 +2,7 @@ use std::ffi::CString;
 use std::fmt::{Display, Formatter};
 
 use bytes::Bytes;
-use enumflags2::{BitFlags, bitflags};
+use enumflags2::{bitflags, BitFlags};
 
 use crate::management::interface::class::{DeviceClass, ServiceClasses};
 use crate::Address;

--- a/src/management/interface/controller.rs
+++ b/src/management/interface/controller.rs
@@ -16,9 +16,9 @@ impl Display for Controller {
     }
 }
 
-impl Into<u16> for Controller {
-    fn into(self) -> u16 {
-        return self.0;
+impl From<Controller> for u16 {
+    fn from(val: Controller) -> Self {
+        val.0
     }
 }
 

--- a/src/management/interface/event.rs
+++ b/src/management/interface/event.rs
@@ -13,11 +13,11 @@ use std::collections::HashMap;
 #[derive(Debug)]
 pub enum Event {
     /// This event is an indication that a command has completed. The
-    ///	fixed set of parameters includes the opcode to identify the
-    ///	command that completed as well as a status value to indicate
-    ///	success or failure. The rest of the parameters are command
-    ///	specific and documented in the section for each command
-    ///	separately.
+    /// fixed set of parameters includes the opcode to identify the
+    /// command that completed as well as a status value to indicate
+    /// success or failure. The rest of the parameters are command
+    /// specific and documented in the section for each command
+    /// separately.
     CommandComplete {
         opcode: Command,
         status: CommandStatus,
@@ -25,47 +25,47 @@ pub enum Event {
     },
 
     /// The command status event is used to indicate an early status for
-    ///	a pending command. In the case that the status indicates failure
-    ///	(anything else except success status) this also means that the
-    ///	command has finished executing.
+    /// a pending command. In the case that the status indicates failure
+    /// (anything else except success status) this also means that the
+    /// command has finished executing.
     CommandStatus {
         opcode: Command,
         status: CommandStatus,
     },
 
     /// This event maps straight to the HCI Hardware Error event and is
-    ///	used to indicate something wrong with the controller hardware.
+    /// used to indicate something wrong with the controller hardware.
     ControllerError { code: u8 },
 
     /// This event indicates that a new controller has been added to the
-    ///	system. It is usually followed by a Read Controller Information
-    ///	command.
+    /// system. It is usually followed by a Read Controller Information
+    /// command.
     IndexAdded,
 
     /// This event indicates that a controller has been removed from the
-    ///	system.
+    /// system.
     IndexRemoved,
 
     /// This event indicates that one or more of the settings for a
-    ///	controller has changed.
+    /// controller has changed.
     NewSettings { settings: ControllerSettings },
 
     /// This event indicates that the Class of Device value for the
-    ///	controller has changed. When the controller is powered off the
-    ///	Class of Device value will always be reported as zero.
+    /// controller has changed. When the controller is powered off the
+    /// Class of Device value will always be reported as zero.
     ClassOfDeviceChanged {
         class: (DeviceClass, ServiceClasses),
     },
 
     /// This event indicates that the local name of the controller has
-    ///	changed.
+    /// changed.
     LocalNameChanged { name: CString, short_name: CString },
 
     /// This event indicates that a new link key has bee generated for a
-    ///	remote device. The `store_hint` parameter indicates whether the
-    ///	host is expected to store the key persistently or not (e.g. this
-    ///	would not be set if the authentication requirement was "No
-    ///	Bonding").
+    /// remote device. The `store_hint` parameter indicates whether the
+    /// host is expected to store the key persistently or not (e.g. this
+    /// would not be set if the authentication requirement was "No
+    /// Bonding").
     NewLinkKey {
         store_hint: bool,
         address: Address,
@@ -76,10 +76,10 @@ pub enum Event {
     },
 
     /// This event indicates that a new long term key has bee generated
-    ///	for a remote device. The `store_hint` parameter indicates whether
-    ///	the host is expected to store the key persistently or not (e.g.
-    ///	this would not be set if the authentication requirement was "No
-    ///	Bonding").
+    /// for a remote device. The `store_hint` parameter indicates whether
+    /// the host is expected to store the key persistently or not (e.g.
+    /// this would not be set if the authentication requirement was "No
+    /// Bonding").
     NewLongTermKey {
         store_hint: bool,
         address: Address,
@@ -92,8 +92,8 @@ pub enum Event {
         value: [u8; 16],
     },
 
-    ///	This event indicates that a successful baseband connection has
-    ///	been created to the remote device.
+    /// This event indicates that a successful baseband connection has
+    /// been created to the remote device.
     DeviceConnected {
         address: Address,
         address_type: AddressType,
@@ -102,16 +102,16 @@ pub enum Event {
     },
 
     /// This event indicates that the baseband connection was lost to a
-    ///	remote device.
+    /// remote device.
     ///
-    ///	Note that the local/remote distinction just determines which side
-    ///	terminated the low-level connection, regardless of the
-    ///	disconnection of the higher-level profiles.
+    /// Note that the local/remote distinction just determines which side
+    /// terminated the low-level connection, regardless of the
+    /// disconnection of the higher-level profiles.
     ///
-    ///	This can sometimes be misleading and thus must be used with care.
-    ///	For example, some hardware combinations would report a locally
-    ///	initiated disconnection even if the user turned Bluetooth off in
-    ///	the remote side.
+    /// This can sometimes be misleading and thus must be used with care.
+    /// For example, some hardware combinations would report a locally
+    /// initiated disconnection even if the user turned Bluetooth off in
+    /// the remote side.
     DeviceDisconnected {
         address: Address,
         address_type: AddressType,
@@ -119,7 +119,7 @@ pub enum Event {
     },
 
     /// This event indicates that a connection attempt failed to a
-    ///	remote device.
+    /// remote device.
     ConnectFailed {
         address: Address,
         address_type: AddressType,
@@ -127,8 +127,8 @@ pub enum Event {
     },
 
     /// This event is used to request a PIN Code reply from user space.
-    ///	The reply should either be returned using the PIN Code Reply or
-    ///	the PIN Code Negative Reply command. If `secure` is true, then
+    /// The reply should either be returned using the PIN Code Reply or
+    /// the PIN Code Negative Reply command. If `secure` is true, then
     /// a secure pin code is required.
     PinCodeRequest {
         address: Address,
@@ -137,14 +137,14 @@ pub enum Event {
     },
 
     /// This event is used to request a user confirmation request from
-    ///	user space. If `confirm_hint` is true this
-    ///	means that a simple "Yes/No" confirmation should be presented to
-    ///	the user instead of a full numerical confirmation (in which case
-    ///	the parameter value will be false).
+    /// user space. If `confirm_hint` is true this
+    /// means that a simple "Yes/No" confirmation should be presented to
+    /// the user instead of a full numerical confirmation (in which case
+    /// the parameter value will be false).
     ///
-    ///	User space should respond to this command either using the User
-    ///	Confirmation Reply or the User Confirmation Negative Reply
-    ///	command.
+    /// User space should respond to this command either using the User
+    /// Confirmation Reply or the User Confirmation Negative Reply
+    /// command.
     UserConfirmationRequest {
         address: Address,
         address_type: AddressType,
@@ -153,15 +153,15 @@ pub enum Event {
     },
 
     /// This event is used to request a passkey from user space. The
-    ///	response to this event should either be the User Passkey Reply
-    ///	command or the User Passkey Negative Reply command.
+    /// response to this event should either be the User Passkey Reply
+    /// command or the User Passkey Negative Reply command.
     UserPasskeyRequest {
         address: Address,
         address_type: AddressType,
     },
 
     /// This event indicates that there was an authentication failure
-    ///	with a remote device.
+    /// with a remote device.
     AuthenticationFailed {
         address: Address,
         address_type: AddressType,
@@ -169,20 +169,20 @@ pub enum Event {
     },
 
     /// This event indicates that a device was found during device
-    ///	discovery.
+    /// discovery.
     ///
-    ///	The Confirm name flag indicates that the kernel wants to know
-    ///	whether user space knows the name for this device or not. If
-    ///	this flag is set user space should respond to it using the
-    ///	Confirm Name command.
+    /// The Confirm name flag indicates that the kernel wants to know
+    /// whether user space knows the name for this device or not. If
+    /// this flag is set user space should respond to it using the
+    /// Confirm Name command.
     ///
-    ///	The Legacy Pairing flag indicates that Legacy Pairing is likely
-    ///	to occur when pairing with this device. An application could use
-    ///	this information to optimize the pairing process by locally
-    ///	pre-generating a PIN code and thereby eliminate the risk of
-    ///	local input timeout when pairing. Note that there is a risk of
-    ///	false-positives for this flag so user space should be able to
-    ///	handle getting something else as a PIN Request when pairing.
+    /// The Legacy Pairing flag indicates that Legacy Pairing is likely
+    /// to occur when pairing with this device. An application could use
+    /// this information to optimize the pairing process by locally
+    /// pre-generating a PIN code and thereby eliminate the risk of
+    /// local input timeout when pairing. Note that there is a risk of
+    /// false-positives for this flag so user space should be able to
+    /// handle getting something else as a PIN Request when pairing.
     DeviceFound {
         address: Address,
         address_type: AddressType,
@@ -192,46 +192,46 @@ pub enum Event {
     },
 
     /// This event indicates that the controller has started discovering
-    ///	devices. This discovering state can come and go multiple times
-    ///	between a StartDiscover and a StopDiscovery command.
+    /// devices. This discovering state can come and go multiple times
+    /// between a StartDiscover and a StopDiscovery command.
     Discovering {
         address_type: BitFlags<AddressTypeFlag>,
         discovering: bool,
     },
 
     /// This event indicates that a device has been blocked using the
-    ///	Block Device command. The event will only be sent to Management
-    ///	sockets other than the one through which the command was sent.
+    /// Block Device command. The event will only be sent to Management
+    /// sockets other than the one through which the command was sent.
     DeviceBlocked {
         address: Address,
         address_type: AddressType,
     },
 
     /// This event indicates that a device has been unblocked using the
-    ///	Unblock Device command. The event will only be sent to
-    ///	Management sockets other than the one through which the command
-    ///	was sent.
+    /// Unblock Device command. The event will only be sent to
+    /// Management sockets other than the one through which the command
+    /// was sent.
     DeviceUnblocked {
         address: Address,
         address_type: AddressType,
     },
 
     /// This event indicates that a device has been unpaired (i.e. all
-    ///	its keys have been removed from the kernel) using the Unpair
-    ///	Device command. The event will only be sent to Management
-    ///	sockets other than the one through which the Unpair Device
-    ///	command was sent.
+    /// its keys have been removed from the kernel) using the Unpair
+    /// Device command. The event will only be sent to Management
+    /// sockets other than the one through which the Unpair Device
+    /// command was sent.
     DeviceUnpaired {
         address: Address,
         address_type: AddressType,
     },
 
     /// This event is used to request passkey notification to the user.
-    ///	Unlike the other authentication events it does not require any response.
+    /// Unlike the other authentication events it does not require any response.
     ///
-    ///	The `passkey` parameter indicates the passkey to be shown to the
-    ///	user. The `entered` parameter indicates how many characters
-    ///	the user has entered on the remote side.
+    /// The `passkey` parameter indicates the passkey to be shown to the
+    /// user. The `entered` parameter indicates how many characters
+    /// the user has entered on the remote side.
     PasskeyNotify {
         address: Address,
         address_type: AddressType,
@@ -240,33 +240,33 @@ pub enum Event {
     },
 
     /// This event indicates that a new identity resolving key has been
-    ///	generated for a remote device.
+    /// generated for a remote device.
     ///
-    ///	The `store_hint` parameter indicates whether the host is expected
-    ///	to store the key persistently or not.
+    /// The `store_hint` parameter indicates whether the host is expected
+    /// to store the key persistently or not.
     ///
-    ///	The `random_address` provides the resolvable random address that
-    ///	was resolved into an identity. A value of 00:00:00:00:00:00
-    ///	indicates that the identity resolving key was provided for
-    ///	a public address or static random address.
+    /// The `random_address` provides the resolvable random address that
+    /// was resolved into an identity. A value of 00:00:00:00:00:00
+    /// indicates that the identity resolving key was provided for
+    /// a public address or static random address.
     ///
-    ///	Once this event has been send for a resolvable random address,
-    ///	all further events mapping this device will send out using the
-    ///	identity address information.
+    /// Once this event has been send for a resolvable random address,
+    /// all further events mapping this device will send out using the
+    /// identity address information.
     ///
-    ///	This event also indicates that now the identity address should
-    ///	be used for commands instead of the resolvable random address.
+    /// This event also indicates that now the identity address should
+    /// be used for commands instead of the resolvable random address.
     ///
-    ///	It is possible that some devices allow discovering via its
-    ///	identity address, but after pairing using resolvable private
-    ///	address only. In such a case `store_hint` will be false` and the
-    ///	`random_address` will indicate `00:00:00:00:00:00`. For these devices,
-    ///	the Privacy Characteristic of the remote GATT database should
-    ///	be consulted to decide if the identity resolving key must be
-    ///	stored persistently or not.
+    /// It is possible that some devices allow discovering via its
+    /// identity address, but after pairing using resolvable private
+    /// address only. In such a case `store_hint` will be false` and the
+    /// `random_address` will indicate `00:00:00:00:00:00`. For these devices,
+    /// the Privacy Characteristic of the remote GATT database should
+    /// be consulted to decide if the identity resolving key must be
+    /// stored persistently or not.
     ///
-    ///	Devices using Set Privacy command with the option 0x02 would
-    ///	be such type of device.
+    /// Devices using Set Privacy command with the option 0x02 would
+    /// be such type of device.
     NewIdentityResolvingKey {
         store_hint: bool,
         random_address: Address,
@@ -276,22 +276,22 @@ pub enum Event {
     },
 
     /// This event indicates that a new signature resolving key has been
-    ///	generated for either the master or slave device.
+    /// generated for either the master or slave device.
     ///
-    ///	The `store_hint` parameter indicates whether the host is expected
-    ///	to store the key persistently or not.
+    /// The `store_hint` parameter indicates whether the host is expected
+    /// to store the key persistently or not.
     ///
-    ///	The local keys are used for signing data to be sent to the
-    ///	remote device, whereas the remote keys are used to verify
-    ///	signatures received from the remote device.
+    /// The local keys are used for signing data to be sent to the
+    /// remote device, whereas the remote keys are used to verify
+    /// signatures received from the remote device.
     ///
-    ///	The local signature resolving key will be generated with each
-    ///	pairing request. Only after receiving this event with the Type
-    ///	indicating a local key is it possible to use ATT Signed Write
-    ///	procedures.
+    /// The local signature resolving key will be generated with each
+    /// pairing request. Only after receiving this event with the Type
+    /// indicating a local key is it possible to use ATT Signed Write
+    /// procedures.
     ///
-    ///	The provided `address` and `address_type` are the identity of
-    ///	a device. So either its public address or static random address.
+    /// The provided `address` and `address_type` are the identity of
+    /// a device. So either its public address or static random address.
     NewSignatureResolvingKey {
         store_hint: bool,
         address: Address,
@@ -301,10 +301,10 @@ pub enum Event {
     },
 
     /// This event indicates that a device has been added using the
-    ///	Add Device command.
+    /// Add Device command.
     ///
-    ///	The event will only be sent to management sockets other than the
-    ///	one through which the command was sent.
+    /// The event will only be sent to management sockets other than the
+    /// one through which the command was sent.
     DeviceAdded {
         address: Address,
         address_type: AddressType,
@@ -312,152 +312,152 @@ pub enum Event {
     },
 
     /// This event indicates that a device has been removed using the
-    ///	Remove Device command.
+    /// Remove Device command.
     ///
-    ///	The event will only be sent to management sockets other than the
-    ///	one through which the command was sent.
+    /// The event will only be sent to management sockets other than the
+    /// one through which the command was sent.
     DeviceRemoved {
         address: Address,
         address_type: AddressType,
     },
 
     /// This event indicates a new set of connection parameters from
-    ///	a peripheral device.
+    /// a peripheral device.
     ///
-    ///	The `store_hint` parameter indicates whether the host is expected
-    ///	to store this information persistently or not.
+    /// The `store_hint` parameter indicates whether the host is expected
+    /// to store this information persistently or not.
     ///
-    ///	The `min_connection_interval`, `max_connection_interval`,
-    ///	`connection_latency` and `supervision_timeout` parameters are
-    ///	encoded as described in Core 4.1 spec, Vol 2, 7.7.65.3.
+    /// The `min_connection_interval`, `max_connection_interval`,
+    /// `connection_latency` and `supervision_timeout` parameters are
+    /// encoded as described in Core 4.1 spec, Vol 2, 7.7.65.3.
     NewConnectionParams {
         store_hint: bool,
         param: ConnectionParams,
     },
 
     /// This event indicates that a new unconfigured controller has been
-    ///	added to the system. It is usually followed by a Read Controller
-    ///	Configuration Information command.
+    /// added to the system. It is usually followed by a Read Controller
+    /// Configuration Information command.
     ///
-    ///	Only when a controller requires further configuration, it will
-    ///	be announced with this event. If it supports configuration, but
-    ///	does not require it, then an Index Added event will be used.
+    /// Only when a controller requires further configuration, it will
+    /// be announced with this event. If it supports configuration, but
+    /// does not require it, then an Index Added event will be used.
     ///
-    ///	Once the Read Extended Controller Index List command has been
-    ///	used at least once, the Extended Index Added event will be
-    ///	send instead of this one.
+    /// Once the Read Extended Controller Index List command has been
+    /// used at least once, the Extended Index Added event will be
+    /// send instead of this one.
     UnconfiguredIndexAdded,
 
     /// This event indicates that an unconfigured controller has been
-    ///	removed from the system.
+    /// removed from the system.
     ///
-    ///	Once the Read Extended Controller Index List command has been
-    ///	used at least once, the Extended Index Removed event will be
-    ///	send instead of this one.
+    /// Once the Read Extended Controller Index List command has been
+    /// used at least once, the Extended Index Removed event will be
+    /// send instead of this one.
     UnconfiguredIndexRemoved,
 
     /// This event indicates that one or more of the options for the
-    ///	controller configuration has changed.
+    /// controller configuration has changed.
     NewConfigOptions {
         missing_options: BitFlags<ControllerConfigOptions>,
     },
 
     /// This event indicates that a new controller index has been
-    ///	added to the system.
+    /// added to the system.
     ///
-    ///	This event will only be used after Read Extended Controller Index
-    ///	List has been used at least once. If it has not been used, then
-    ///	Index Added and Unconfigured Index Added are sent instead.
+    /// This event will only be used after Read Extended Controller Index
+    /// List has been used at least once. If it has not been used, then
+    /// Index Added and Unconfigured Index Added are sent instead.
     ExtendedIndexAdded {
         controller_type: ControllerType,
         controller_bus: ControllerBus,
     },
 
     /// This event indicates that a new controller index has been
-    ///	removed from the system.
+    /// removed from the system.
     ///
-    ///	This event will only be used after Read Extended Controller Index
-    ///	List has been used at least once. If it has not been used, then
-    ///	Index Added and Unconfigured Index Added are sent instead.
+    /// This event will only be used after Read Extended Controller Index
+    /// List has been used at least once. If it has not been used, then
+    /// Index Added and Unconfigured Index Added are sent instead.
     ExtendedIndexRemoved {
         controller_type: ControllerType,
         controller_bus: ControllerBus,
     },
 
     /// This event is used when the Read Local Out Of Band Extended Data
-    ///	command has been used and some other user requested a new set
-    ///	of local out-of-band data. This allows for the original caller
-    ///	to adjust the data.
+    /// command has been used and some other user requested a new set
+    /// of local out-of-band data. This allows for the original caller
+    /// to adjust the data.
     ///
-    ///	When LE Privacy is used and LE Secure Connections out-of-band
-    ///	data has been requested, then this event will be emitted every
-    ///	time the Resolvable Private Address (RPA) gets changed. The new
-    ///	RPA will be included in the `eir_data`.
+    /// When LE Privacy is used and LE Secure Connections out-of-band
+    /// data has been requested, then this event will be emitted every
+    /// time the Resolvable Private Address (RPA) gets changed. The new
+    /// RPA will be included in the `eir_data`.
     ///
-    ///	The event will only be sent to management sockets other than the
-    ///	one through which the command was sent. It will additionally also
-    ///	only be sent to sockets that have used the command at least once.
+    /// The event will only be sent to management sockets other than the
+    /// one through which the command was sent. It will additionally also
+    /// only be sent to sockets that have used the command at least once.
     LocalOutOfBandExtDataUpdated {
         address_type: AddressType,
         eir_data: Bytes,
     },
 
     /// This event indicates that an advertising instance has been added
-    ///	using the Add Advertising command.
+    /// using the Add Advertising command.
     ///
-    ///	The event will only be sent to management sockets other than the
-    ///	one through which the command was sent.
+    /// The event will only be sent to management sockets other than the
+    /// one through which the command was sent.
     AdvertisingAdded { instance: u8 },
 
     /// This event indicates that an advertising instance has been removed
-    ///	using the Remove Advertising command.
+    /// using the Remove Advertising command.
     ///
-    ///	The event will only be sent to management sockets other than the
-    ///	one through which the command was sent.
+    /// The event will only be sent to management sockets other than the
+    /// one through which the command was sent.
     AdvertisingRemoved { instance: u8 },
 
     /// This event indicates that controller information has been updated
-    ///	and new values are used. This includes the local name, class of
-    ///	device, device id and LE address information.
+    /// and new values are used. This includes the local name, class of
+    /// device, device id and LE address information.
     ///
-    ///	This event will only be used after Read Extended Controller
-    ///	Information command has been used at least once. If it has not
-    ///	been used the legacy events are used.
+    /// This event will only be used after Read Extended Controller
+    /// Information command has been used at least once. If it has not
+    /// been used the legacy events are used.
     ///
-    ///	The event will only be sent to management sockets other than the
-    ///	one through which the change was triggered.
+    /// The event will only be sent to management sockets other than the
+    /// one through which the change was triggered.
     ExtControllerInfoChanged { eir_data: Bytes },
 
     /// This event indicates that an advertising instance has been added
-    ///	using the Add Advertising command.
+    /// using the Add Advertising command.
     ///
-    ///	The event will only be sent to management sockets other than the
-    ///	one through which the command was sent.
+    /// The event will only be sent to management sockets other than the
+    /// one through which the command was sent.
     PhyConfigChanged { selected_phys: BitFlags<PhyFlag> },
 
-    ///	This event indicates that the status of an experimental feature
-    ///	has been changed.
+    /// This event indicates that the status of an experimental feature
+    /// has been changed.
     ///
-    ///	The event will only be sent to management sockets other than the
-    ///	one through which the change was triggered.
+    /// The event will only be sent to management sockets other than the
+    /// one through which the change was triggered.
     ExperimentalFeatureChanged {
         uuid: [u8; 16],
         flags: u32,
     },
 
-    ///	This event indicates the change of default system parameter values.
+    /// This event indicates the change of default system parameter values.
     ///
     /// The event will only be sent to management sockets other than the
-    ///	one through which the change was trigged. In addition it will
-    ///	only be sent to sockets that have issues the Read Default System
-    ///	Configuration command.
+    /// one through which the change was trigged. In addition it will
+    /// only be sent to sockets that have issues the Read Default System
+    /// Configuration command.
     DefaultSystemConfigChanged { params: HashMap<SystemConfigParameterType, Vec<u8>> },
 
-    ///	This event indicates the change of default runtime parameter values.
+    /// This event indicates the change of default runtime parameter values.
     ///
-    ///	The event will only be sent to management sockets other than the
-    ///	one through which the change was trigged. In addition it will
-    ///	only be sent to sockets that have issues the Read Default Runtime
-    ///	Configuration command.
+    /// The event will only be sent to management sockets other than the
+    /// one through which the change was trigged. In addition it will
+    /// only be sent to sockets that have issues the Read Default Runtime
+    /// Configuration command.
     DefaultRuntimeConfigChanged { params: HashMap<RuntimeConfigParameterType, Vec<u8>> },
 }

--- a/src/management/interface/request.rs
+++ b/src/management/interface/request.rs
@@ -10,14 +10,14 @@ pub struct Request {
     pub param: Bytes,
 }
 
-impl Into<Bytes> for Request {
-    fn into(self) -> Bytes {
-        let mut buf = BytesMut::with_capacity(6 + self.param.len());
+impl From<Request> for Bytes {
+    fn from(val: Request) -> Self {
+        let mut buf = BytesMut::with_capacity(6 + val.param.len());
 
-        buf.put_u16_le(self.opcode as u16);
-        buf.put_u16_le(self.controller.into());
-        buf.put_u16_le(self.param.len() as u16);
-        buf.put(self.param);
+        buf.put_u16_le(val.opcode as u16);
+        buf.put_u16_le(val.controller.into());
+        buf.put_u16_le(val.param.len() as u16);
+        buf.put(val.param);
 
         buf.freeze()
     }

--- a/src/management/interface/response.rs
+++ b/src/management/interface/response.rs
@@ -64,16 +64,16 @@ impl Response {
                 0x0009 => Event::NewLinkKey {
                     store_hint: buf.get_bool(),
                     address: Address::from_buf(&mut buf),
-                    address_type: FromPrimitive::from_u8(buf.get_u8()).unwrap(),
-                    key_type: FromPrimitive::from_u8(buf.get_u8()).unwrap(),
+                    address_type: FromPrimitive::from_u8(buf.get_u8()).ok_or(Error::InvalidData)?,
+                    key_type: FromPrimitive::from_u8(buf.get_u8()).ok_or(Error::InvalidData)?,
                     value: buf.get_u8x16(),
                     pin_length: buf.get_u8(),
                 },
                 0x000A => Event::NewLongTermKey {
                     store_hint: buf.get_bool(),
                     address: Address::from_buf(&mut buf),
-                    address_type: FromPrimitive::from_u8(buf.get_u8()).unwrap(),
-                    key_type: FromPrimitive::from_u8(buf.get_u8()).unwrap(),
+                    address_type: FromPrimitive::from_u8(buf.get_u8()).ok_or(Error::InvalidData)?,
+                    key_type: FromPrimitive::from_u8(buf.get_u8()).ok_or(Error::InvalidData)?,
                     master: buf.get_u8(),
                     encryption_size: buf.get_u8(),
                     encryption_diversifier: buf.get_u16_le(),
@@ -82,7 +82,7 @@ impl Response {
                 },
                 0x000B => Event::DeviceConnected {
                     address: Address::from_buf(&mut buf),
-                    address_type: FromPrimitive::from_u8(buf.get_u8()).unwrap(),
+                    address_type: FromPrimitive::from_u8(buf.get_u8()).ok_or(Error::InvalidData)?,
                     flags: BitFlags::from_bits_truncate(buf.get_u32_le()),
                     eir_data: {
                         let len = buf.get_u16_le() as usize;
@@ -91,37 +91,37 @@ impl Response {
                 },
                 0x000C => Event::DeviceDisconnected {
                     address: Address::from_buf(&mut buf),
-                    address_type: FromPrimitive::from_u8(buf.get_u8()).unwrap(),
-                    reason: FromPrimitive::from_u8(buf.get_u8()).unwrap(),
+                    address_type: FromPrimitive::from_u8(buf.get_u8()).ok_or(Error::InvalidData)?,
+                    reason: FromPrimitive::from_u8(buf.get_u8()).ok_or(Error::InvalidData)?,
                 },
                 0x000D => Event::ConnectFailed {
                     address: Address::from_buf(&mut buf),
-                    address_type: FromPrimitive::from_u8(buf.get_u8()).unwrap(),
+                    address_type: FromPrimitive::from_u8(buf.get_u8()).ok_or(Error::InvalidData)?,
                     status: buf.get_u8(),
                 },
                 0x000E => Event::PinCodeRequest {
                     address: Address::from_buf(&mut buf),
-                    address_type: FromPrimitive::from_u8(buf.get_u8()).unwrap(),
+                    address_type: FromPrimitive::from_u8(buf.get_u8()).ok_or(Error::InvalidData)?,
                     secure: buf.get_bool(),
                 },
                 0x000F => Event::UserConfirmationRequest {
                     address: Address::from_buf(&mut buf),
-                    address_type: FromPrimitive::from_u8(buf.get_u8()).unwrap(),
+                    address_type: FromPrimitive::from_u8(buf.get_u8()).ok_or(Error::InvalidData)?,
                     confirm_hint: buf.get_bool(),
                     value: buf.get_u32_le(),
                 },
                 0x0010 => Event::UserPasskeyRequest {
                     address: Address::from_buf(&mut buf),
-                    address_type: FromPrimitive::from_u8(buf.get_u8()).unwrap(),
+                    address_type: FromPrimitive::from_u8(buf.get_u8()).ok_or(Error::InvalidData)?,
                 },
                 0x0011 => Event::AuthenticationFailed {
                     address: Address::from_buf(&mut buf),
-                    address_type: FromPrimitive::from_u8(buf.get_u8()).unwrap(),
+                    address_type: FromPrimitive::from_u8(buf.get_u8()).ok_or(Error::InvalidData)?,
                     status: buf.get_u8(),
                 },
                 0x0012 => Event::DeviceFound {
                     address: Address::from_buf(&mut buf),
-                    address_type: FromPrimitive::from_u8(buf.get_u8()).unwrap(),
+                    address_type: FromPrimitive::from_u8(buf.get_u8()).ok_or(Error::InvalidData)?,
                     rssi: buf.get_i8(),
                     flags: BitFlags::from_bits_truncate(buf.get_u32_le()),
                     eir_data: {
@@ -135,19 +135,19 @@ impl Response {
                 },
                 0x0014 => Event::DeviceBlocked {
                     address: Address::from_buf(&mut buf),
-                    address_type: FromPrimitive::from_u8(buf.get_u8()).unwrap(),
+                    address_type: FromPrimitive::from_u8(buf.get_u8()).ok_or(Error::InvalidData)?,
                 },
                 0x0015 => Event::DeviceUnblocked {
                     address: Address::from_buf(&mut buf),
-                    address_type: FromPrimitive::from_u8(buf.get_u8()).unwrap(),
+                    address_type: FromPrimitive::from_u8(buf.get_u8()).ok_or(Error::InvalidData)?,
                 },
                 0x0016 => Event::DeviceUnpaired {
                     address: Address::from_buf(&mut buf),
-                    address_type: FromPrimitive::from_u8(buf.get_u8()).unwrap(),
+                    address_type: FromPrimitive::from_u8(buf.get_u8()).ok_or(Error::InvalidData)?,
                 },
                 0x0017 => Event::PasskeyNotify {
                     address: Address::from_buf(&mut buf),
-                    address_type: FromPrimitive::from_u8(buf.get_u8()).unwrap(),
+                    address_type: FromPrimitive::from_u8(buf.get_u8()).ok_or(Error::InvalidData)?,
                     passkey: buf.get_u32_le(),
                     entered: buf.get_u8(),
                 },

--- a/src/util.rs
+++ b/src/util.rs
@@ -58,7 +58,7 @@ pub(crate) trait BufExtBlueZ: Buf {
             bytes.push(current);
             current = self.get_u8();
         }
-        return unsafe { CString::from_vec_unchecked(bytes) };
+        unsafe { CString::from_vec_unchecked(bytes) }
     }
 
     /// Parses a list of Type/Length/Value entries into a map keyed by type


### PR DESCRIPTION
I was looking at bluez-rs to figure out how it works, and tweaked a few issues (a few of them rust_analyzer pointed out).

This PR is probably best read by looking at individual commits in isolation -- let me know if you'd rather I split it into multiple PRs, but each commit has a good enough explanation and is well-understandable in isolation.

I got rid of quite a few `unwrap()`s... again: I was mostly trying to figure out how the involved parts worked, but used the opportunity to tweak those, since it reduces the changes of panicking, even when the library is slightly misused.