### PR TITLE
Drop unnecessary `sleep` calls

### DIFF
--- a/examples/discover.rs
+++ b/examples/discover.rs
@@ -6,9 +6,8 @@
 extern crate bluez;
 
 use std::error::Error;
-use std::time::Duration;
 
-use async_std::task::{block_on, sleep};
+use async_std::task::block_on;
 
 use bluez::management::client::*;
 use bluez::management::interface::controller::*;
@@ -90,7 +89,5 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             }
             _ => (),
         }
-
-        sleep(Duration::from_millis(50)).await;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,6 @@
 //!
 //! for _ in 0usize..5000usize {
 //!     client.process().await?;
-//!     std::thread::sleep(Duration::from_millis(50));
 //! }
 //! #  Ok(())
 //! # }


### PR DESCRIPTION
Because the main loop uses `await` when fetching new events to process,
if there are no events the main thread simply pauses execution until
there is more IO to be done.

The sleep call is not necessary due to the async nature of the library,
and will just add an artificial delay to events, as well as an extra
wakeup.

Closes #29